### PR TITLE
Empty InterpretedProgram and Interpreter classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ add_library(
 
     src/networkprotocoldsl/entrypoint.cpp
     src/networkprotocoldsl/entrypoint.hpp
+    src/networkprotocoldsl/interpretedprogram.hpp
+    src/networkprotocoldsl/interpretedprogram.cpp
+    src/networkprotocoldsl/interpreter.hpp
+    src/networkprotocoldsl/interpreter.cpp
 )
 
 target_include_directories(

--- a/src/networkprotocoldsl/interpretedprogram.cpp
+++ b/src/networkprotocoldsl/interpretedprogram.cpp
@@ -1,0 +1,1 @@
+#include <networkprotocoldsl/interpretedprogram.hpp>

--- a/src/networkprotocoldsl/interpretedprogram.hpp
+++ b/src/networkprotocoldsl/interpretedprogram.hpp
@@ -1,0 +1,37 @@
+#ifndef NETWORKPROTOCOLDSL_INTERPRETEDPROGRAM_HPP
+#define NETWORKPROTOCOLDSL_INTERPRETERPROGRAM_HPP
+
+#include <string>
+
+#include <networkprotocoldsl/interpreter.hpp>
+
+namespace networkprotocoldsl {
+
+  /***
+   * The InterpretedProgram object represents the usage of a single program.
+   *
+   * Many instances of an interpreter can be spawned for a
+   * program. This is where the parsing of the programming language
+   * will take place, and from which a new instance can be
+   * instantiated to deal with a specific connection.
+   */
+  class InterpretedProgram {
+    std::string source_file;
+  public:
+
+    /***
+     * Parses source code and creates the object that can be used to
+     * instantiate interpreters for this specific code.
+     */
+    InterpretedProgram(std::string sf) :source_file(sf) {}
+
+    /***
+     * Obtains an instance of an interpreter for this program.
+     */
+    Interpreter get_instance() { return Interpreter(); };
+
+  };
+
+}
+
+#endif // NETWORKPROTOCOLDSL_INTERPRETER_HPP

--- a/src/networkprotocoldsl/interpreter.cpp
+++ b/src/networkprotocoldsl/interpreter.cpp
@@ -1,0 +1,1 @@
+#include <networkprotocoldsl/interpreter.hpp>

--- a/src/networkprotocoldsl/interpreter.hpp
+++ b/src/networkprotocoldsl/interpreter.hpp
@@ -1,0 +1,27 @@
+#ifndef NETWORKPROTOCOLDSL_INTERPRETER_HPP
+#define NETWORKPROTOCOLDSL_INTERPRETER_HPP
+
+namespace networkprotocoldsl {
+
+  /***
+   * The InterpretedProgram object represents the usage of a single program.
+   *
+   * Many instances of an interpreter can be spawned for a
+   * program. This is where the parsing of the programming language
+   * will take place, and from which a new instance can be
+   * instantiated to deal with a specific connection.
+   */
+  class Interpreter {
+  public:
+
+    /***
+     * An interpreter is constructed from an already parsed program
+     * tobe executed in the context of a given socket.
+     */
+    Interpreter() {};
+
+  };
+
+}
+
+#endif // NETWORKPROTOCOLDSL_INTERPRETER_HPP

--- a/tests/002-interpreter-state.cpp
+++ b/tests/002-interpreter-state.cpp
@@ -1,0 +1,11 @@
+#include <networkprotocoldsl/interpretedprogram.hpp>
+#include <networkprotocoldsl/interpreter.hpp>
+
+#include <gtest/gtest.h>
+#include <string>
+
+TEST(starting_the_interpreter, empty_program) {
+  std::string test_file = "data/002-empty-program.networkprotocoldsl";
+  networkprotocoldsl::InterpretedProgram program(test_file);
+  networkprotocoldsl::Interpreter interpreter = program.get_instance();
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(GTest REQUIRED)
 foreach(
     TEST
     001-empty
+    002-interpreter-state
 )
     add_executable(${TEST}.t ${TEST}.cpp)
     target_link_libraries(

--- a/tests/data/002-empty-program.networkprotocoldsl
+++ b/tests/data/002-empty-program.networkprotocoldsl
@@ -1,0 +1,5 @@
+message "Server Automatically Closes" { 
+    sender: Server; 
+    when: Connected; 
+    then: Closed; 
+}


### PR DESCRIPTION
This demonstrates, in the tests, how we intend to have those APIs being used by the user.