### PR TITLE
Refactoring to support more types of operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *~
+build
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,30 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_library(
     networkprotocoldsl
 
+    src/networkprotocoldsl/continuation.cpp
+    src/networkprotocoldsl/continuation.hpp
     src/networkprotocoldsl/entrypoint.cpp
     src/networkprotocoldsl/entrypoint.hpp
+    src/networkprotocoldsl/executionstackframe.hpp
+    src/networkprotocoldsl/executionstackframe.cpp
     src/networkprotocoldsl/interpretedprogram.hpp
     src/networkprotocoldsl/interpretedprogram.cpp
     src/networkprotocoldsl/interpreter.hpp
     src/networkprotocoldsl/interpreter.cpp
     src/networkprotocoldsl/value.hpp
     src/networkprotocoldsl/value.cpp
+    src/networkprotocoldsl/operation/int32literal.hpp
+    src/networkprotocoldsl/operation/int32literal.cpp
+    src/networkprotocoldsl/operation/add.hpp
+    src/networkprotocoldsl/operation/add.cpp
+    src/networkprotocoldsl/operation/unarycallback.hpp
+    src/networkprotocoldsl/operation/unarycallback.cpp
+    src/networkprotocoldsl/operation/readint32native.hpp
+    src/networkprotocoldsl/operation/readint32native.cpp
     src/networkprotocoldsl/operation.hpp
     src/networkprotocoldsl/operation.cpp
+    src/networkprotocoldsl/operationconcepts.hpp
+    src/networkprotocoldsl/operationconcepts.cpp
     src/networkprotocoldsl/optree.hpp
     src/networkprotocoldsl/optree.cpp
 )
@@ -25,6 +39,12 @@ target_include_directories(
     networkprotocoldsl
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/
+)
+
+target_compile_options(
+    networkprotocoldsl
+    PUBLIC
+    -fconcepts-diagnostics-depth=10
 )
 
 enable_testing()

--- a/src/networkprotocoldsl/continuation.cpp
+++ b/src/networkprotocoldsl/continuation.cpp
@@ -1,0 +1,104 @@
+#include <networkprotocoldsl/continuation.hpp>
+
+namespace networkprotocoldsl {
+
+template <InterpretedOperationConcept O>
+static std::string _get_callback_key(Continuation *c, const O &o) {
+  return "N/A";
+}
+
+template <CallbackOperationConcept O>
+static std::string _get_callback_key(Continuation *c, const O &o) {
+  return o.callback_key(
+      std::get<CallbackOperationContext>(c->top().get_context()));
+}
+
+template <InputOutputOperationConcept O>
+static std::string _get_callback_key(Continuation *c, const O &o) {
+  return "N/A";
+}
+
+template <InterpretedOperationConcept O>
+static void _set_callback_called(Continuation *c, const O &o) {}
+
+template <CallbackOperationConcept O>
+static void _set_callback_called(Continuation *c, const O &o) {
+  o.set_callback_called(
+      std::get<CallbackOperationContext>(c->top().get_context()));
+}
+
+template <InputOutputOperationConcept O>
+static void _set_callback_called(Continuation *c, const O &o) {}
+
+template <InterpretedOperationConcept O>
+static void _set_callback_return(Continuation *c, const O &o, Value v) {}
+
+template <CallbackOperationConcept O>
+static void _set_callback_return(Continuation *c, const O &o, Value v) {
+  o.set_callback_return(
+      std::get<CallbackOperationContext>(c->top().get_context()), v);
+}
+
+template <InputOutputOperationConcept O>
+static void _set_callback_return(Continuation *c, const O &o, Value v) {}
+
+static ContinuationState map_result_to_state(Value v) {
+  return ContinuationState::Ready;
+}
+
+static ContinuationState map_result_to_state(ReasonForBlockedOperation r) {
+  return ContinuationState::Blocked;
+}
+
+Continuation::Continuation(const OpTreeNode &o) {
+  stack.push(ExecutionStackFrame(o));
+}
+
+ExecutionStackFrame &Continuation::top() { return stack.top(); }
+
+ContinuationState Continuation::result_to_state() {
+  return std::visit([this](auto &r) { return map_result_to_state(r); }, result);
+}
+
+ContinuationState Continuation::step() {
+  if (stack.size()) {
+    while (!stack.top().has_arguments_ready()) {
+      stack.push(stack.top().next_op());
+    }
+    result = stack.top().execute();
+    state = result_to_state();
+    if (state == ContinuationState::Ready) {
+      stack.pop();
+      if (stack.size()) {
+        stack.top().push_back(std::get<Value>(result));
+      } else {
+        state = ContinuationState::Exited;
+      }
+    }
+    return state;
+  } else {
+    return ContinuationState::Exited;
+  }
+}
+
+OperationResult Continuation::get_result() { return result; }
+
+std::string Continuation::get_callback_key() {
+  return std::visit([this](auto &o) { return _get_callback_key(this, o); },
+                    stack.top().get_operation());
+}
+
+void Continuation::set_callback_called() {
+  std::visit([this](auto &o) { return _set_callback_called(this, o); },
+             stack.top().get_operation());
+}
+
+const std::vector<Value> &Continuation::get_callback_arguments() {
+  return stack.top().get_accumulator();
+}
+
+void Continuation::set_callback_return(Value v) {
+  std::visit([this, v](auto &o) { _set_callback_return(this, o, v); },
+             stack.top().get_operation());
+}
+}; // namespace networkprotocoldsl

--- a/src/networkprotocoldsl/continuation.hpp
+++ b/src/networkprotocoldsl/continuation.hpp
@@ -1,0 +1,48 @@
+#ifndef INCLUDED_NETWORKPROTOCOLDSL_CONTINUATION_HPP
+#define INCLUDED_NETWORKPROTOCOLDSL_CONTINUATION_HPP
+
+#include <networkprotocoldsl/executionstackframe.hpp>
+
+#include <stack>
+
+namespace networkprotocoldsl {
+
+/**
+ * Represents the state of the execution consider external factors,
+ * such as waiting for a callback to be evaluated.
+ */
+enum class ContinuationState { MissingArguments, Ready, Blocked, Exited };
+
+/**
+ * A continuation represents the state of a single thread of execution
+ * within a intepreter. The interpreter may have many of those
+ * running.
+ */
+class Continuation {
+  std::stack<ExecutionStackFrame> stack;
+  ContinuationState state = ContinuationState::MissingArguments;
+  OperationResult result;
+
+public:
+  Continuation(const OpTreeNode &o);
+
+  ExecutionStackFrame &top();
+
+  ContinuationState result_to_state();
+
+  ContinuationState step();
+
+  OperationResult get_result();
+
+  std::string get_callback_key();
+
+  void set_callback_called();
+
+  const std::vector<Value> &get_callback_arguments();
+
+  void set_callback_return(Value v);
+};
+
+} // namespace networkprotocoldsl
+
+#endif

--- a/src/networkprotocoldsl/executionstackframe.cpp
+++ b/src/networkprotocoldsl/executionstackframe.cpp
@@ -1,0 +1,104 @@
+#include <networkprotocoldsl/executionstackframe.hpp>
+
+#include <cassert>
+
+namespace networkprotocoldsl {
+
+template <std::size_t... Indices>
+static auto make_argument_tuple(const std::vector<Value> &v,
+                                std::index_sequence<Indices...>) {
+  return std::make_tuple(v[Indices]...);
+}
+
+template <InterpretedOperationConcept O>
+static OperationContextVariant initialize_context(const O &o) {
+  return false;
+}
+
+template <CallbackOperationConcept O>
+static OperationContextVariant initialize_context(const O &o) {
+  return CallbackOperationContext();
+}
+
+template <InputOutputOperationConcept O>
+static OperationContextVariant initialize_context(const O &o) {
+  return InputOutputOperationContext();
+}
+
+template <OperationConcept O>
+static bool operation_has_arguments_ready(ExecutionStackFrame *frame,
+                                          const O &o) {
+  if (frame->get_accumulator().size() <
+      std::tuple_size<typename O::Arguments>::value) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+template <InterpretedOperationConcept O>
+static OperationResult execute_specific_operation(ExecutionStackFrame *frame,
+                                                  const O &o) {
+  typename O::Arguments args(make_argument_tuple(
+      frame->get_accumulator(),
+      std::make_index_sequence<
+          std::tuple_size<typename O::Arguments>::value>()));
+  return o(args);
+}
+
+template <CallbackOperationConcept O>
+static OperationResult execute_specific_operation(ExecutionStackFrame *frame,
+                                                  const O &o) {
+  typename O::Arguments args(make_argument_tuple(
+      frame->get_accumulator(),
+      std::make_index_sequence<
+          std::tuple_size<typename O::Arguments>::value>()));
+  return o(std::get<CallbackOperationContext>(frame->get_context()), args);
+}
+
+template <InputOutputOperationConcept O>
+static OperationResult execute_specific_operation(ExecutionStackFrame *frame,
+                                                  const O &o) {
+  typename O::Arguments args(make_argument_tuple(
+      frame->get_accumulator(),
+      std::make_index_sequence<
+          std::tuple_size<typename O::Arguments>::value>()));
+  return o(std::get<InputOutputOperationContext>(frame->get_context()), args);
+}
+
+ExecutionStackFrame::ExecutionStackFrame(const OpTreeNode &o) : optreenode(o) {
+  ctx = std::visit([this](auto &o) { return initialize_context(o); },
+                   optreenode.operation);
+}
+
+bool ExecutionStackFrame::has_arguments_ready() {
+  return std::visit(
+      [this](auto &o) { return operation_has_arguments_ready(this, o); },
+      optreenode.operation);
+}
+
+OperationResult ExecutionStackFrame::execute() {
+  assert(has_arguments_ready());
+  return std::visit(
+      [this](auto &o) { return execute_specific_operation(this, o); },
+      optreenode.operation);
+}
+
+void ExecutionStackFrame::push_back(Value v) { accumulator.push_back(v); }
+
+const OpTreeNode &ExecutionStackFrame::next_op() {
+  assert(!has_arguments_ready());
+  return optreenode.children[accumulator.size()];
+}
+
+const Operation &ExecutionStackFrame::get_operation() {
+  return optreenode.operation;
+}
+
+OperationContextVariant &ExecutionStackFrame::get_context() { return ctx; }
+
+std::vector<Value> &ExecutionStackFrame::get_accumulator() {
+  return accumulator;
+}
+
+} // namespace networkprotocoldsl

--- a/src/networkprotocoldsl/executionstackframe.hpp
+++ b/src/networkprotocoldsl/executionstackframe.hpp
@@ -1,0 +1,47 @@
+#ifndef INCLUDED_NETWORKPROTOCOLDSL_EXECUTIONSTACKFRAME_HPP
+#define INCLUDED_NETWORKPROTOCOLDSL_EXECUTIONSTACKFRAME_HPP
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <tuple>
+
+#include <networkprotocoldsl/operationconcepts.hpp>
+#include <networkprotocoldsl/optree.hpp>
+
+namespace networkprotocoldsl {
+
+using OperationContextVariant =
+    std::variant<bool, CallbackOperationContext, InputOutputOperationContext>;
+
+/**
+ * The execution frame points to a specific operation and the
+ * accumulation of inputs for that operation. The actual operation can
+ * only happen when the right number of inputs has been provided.
+ */
+class ExecutionStackFrame {
+  const OpTreeNode &optreenode;
+  std::vector<Value> accumulator;
+  OperationContextVariant ctx;
+
+public:
+  ExecutionStackFrame(const OpTreeNode &o);
+
+  bool has_arguments_ready();
+
+  OperationResult execute();
+
+  void push_back(Value v);
+
+  const OpTreeNode &next_op();
+
+  const Operation &get_operation();
+
+  OperationContextVariant &get_context();
+
+  std::vector<Value> &get_accumulator();
+};
+
+} // namespace networkprotocoldsl
+
+#endif

--- a/src/networkprotocoldsl/interpreter.hpp
+++ b/src/networkprotocoldsl/interpreter.hpp
@@ -1,154 +1,14 @@
 #ifndef NETWORKPROTOCOLDSL_INTERPRETER_HPP
 #define NETWORKPROTOCOLDSL_INTERPRETER_HPP
 
-#include <networkprotocoldsl/operation.hpp>
-#include <networkprotocoldsl/optree.hpp>
+#include <networkprotocoldsl/continuation.hpp>
 
 #include <cassert>
 #include <memory>
 #include <stack>
+#include <variant>
 
 namespace networkprotocoldsl {
-
-/**
- * Represents the state of the execution consider external factors,
- * such as waiting for a callback to be evaluated.
- */
-enum class ExecutionStackFrameState {
-  MissingArguments,
-  WaitingForCallback,
-  WaitingCallbackData,
-  Ready,
-  Exited
-};
-
-/**
- * The execution frame points to a specific operation and the
- * accumulation of inputs for that operation. The actual operation can
- * only happen when the right number of inputs has been provided.
- */
-class ExecutionStackFrame {
-  const OpTreeNode &optreenode;
-  std::vector<Value> accumulator;
-  std::optional<std::string> callback_key;
-  bool callback_called = false;
-
-  template <std::size_t... Indices>
-  auto make_argument_tuple(const std::vector<Value> &v,
-                           std::index_sequence<Indices...>) {
-    return std::make_tuple(v[Indices]...);
-  }
-
-  template <OperationConcept O>
-  ExecutionStackFrameState is_specific_operation_ready(const O &o) {
-    if (accumulator.size() < std::tuple_size<typename O::Arguments>::value) {
-      return ExecutionStackFrameState::MissingArguments;
-    } else {
-      callback_key = o.callback_key();
-      if (callback_key.has_value()) {
-        if (callback_called) {
-          return ExecutionStackFrameState::WaitingCallbackData;
-        } else {
-          return ExecutionStackFrameState::WaitingForCallback;
-        }
-      } else {
-        return ExecutionStackFrameState::Ready;
-      }
-    }
-  }
-
-  template <OperationConcept O> Value execute_specific_operation(const O &o) {
-    typename O::Arguments args(make_argument_tuple(
-        accumulator, std::make_index_sequence<
-                         std::tuple_size<typename O::Arguments>::value>()));
-    assert(!callback_key.has_value());
-    return o(args);
-  }
-
-public:
-  ExecutionStackFrame(const OpTreeNode &o) : optreenode(o) {}
-
-  ExecutionStackFrameState is_ready() {
-    return std::visit(
-        [this](auto &o) { return is_specific_operation_ready(o); },
-        optreenode.operation);
-  }
-
-  Value execute() {
-    return std::visit([this](auto &o) { return execute_specific_operation(o); },
-                      optreenode.operation);
-  }
-
-  void push_back(Value v) { accumulator.push_back(v); }
-
-  const OpTreeNode &next_op() {
-    assert(is_ready() == ExecutionStackFrameState::MissingArguments);
-    return optreenode.children[accumulator.size()];
-  }
-
-  std::optional<std::string> get_callback_key() { return callback_key; }
-
-  void set_callback_called() { callback_called = true; }
-};
-
-/**
- * A continuation represents the state of a single thread of execution
- * within a intepreter. The interpreter may have many of those
- * running.
- */
-class Continuation {
-  std::stack<ExecutionStackFrame> stack;
-  std::optional<Value> result;
-
-public:
-  Continuation(const OpTreeNode &o) { stack.push(ExecutionStackFrame(o)); }
-
-  ExecutionStackFrameState step() {
-    if (stack.size()) {
-      ExecutionStackFrameState state;
-      while ((state = stack.top().is_ready()) ==
-             ExecutionStackFrameState::MissingArguments) {
-        stack.push(stack.top().next_op());
-      }
-      if (state == ExecutionStackFrameState::Ready) {
-        result = stack.top().execute();
-        stack.pop();
-        if (stack.size()) {
-          stack.top().push_back(*result);
-          return stack.top().is_ready();
-        } else {
-          return ExecutionStackFrameState::Exited;
-        }
-      } else {
-        return state;
-      }
-    } else {
-      return ExecutionStackFrameState::Exited;
-    }
-  }
-
-  std::optional<Value> get_result() { return result; }
-
-  std::optional<std::string> get_callback_key() {
-    assert(stack.size() > 0);
-    return stack.top().get_callback_key();
-  }
-
-  void set_callback_called() {
-    assert(stack.size() > 0);
-    stack.top().set_callback_called();
-  }
-
-  void set_callback_return(Value v) {
-    assert(stack.size() > 0);
-    assert(stack.top().get_callback_key().has_value());
-    result = v;
-    stack.pop();
-    if (stack.size()) {
-      stack.top().push_back(v);
-    }
-  }
-};
 
 /***
  * The InterpretedProgram object represents the usage of a single program.
@@ -170,15 +30,19 @@ public:
   Interpreter(std::shared_ptr<const OpTree> o)
       : optree(o), continuation(o->root){};
 
-  ExecutionStackFrameState step() { return continuation.step(); }
+  ContinuationState step() { return continuation.step(); }
 
-  std::optional<Value> get_result() { return continuation.get_result(); }
+  ContinuationState result_to_state() { return continuation.result_to_state(); }
 
-  std::optional<std::string> get_callback_key() {
-    return continuation.get_callback_key();
-  }
+  OperationResult get_result() { return continuation.get_result(); }
+
+  std::string get_callback_key() { return continuation.get_callback_key(); }
 
   void set_callback_called() { continuation.set_callback_called(); }
+
+  const std::vector<Value> &get_callback_arguments() {
+    return continuation.get_callback_arguments();
+  }
 
   void set_callback_return(Value v) { continuation.set_callback_return(v); }
 };

--- a/src/networkprotocoldsl/operation.hpp
+++ b/src/networkprotocoldsl/operation.hpp
@@ -1,74 +1,14 @@
 #ifndef NETWORKPROTOCOLDSL_OPERATION_HPP
 #define NETWORKPROTOCOLDSL_OPERATION_HPP
 
-#include <networkprotocoldsl/value.hpp>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <tuple>
 #include <variant>
 
+#include <networkprotocoldsl/operation/add.hpp>
+#include <networkprotocoldsl/operation/int32literal.hpp>
+#include <networkprotocoldsl/operation/readint32native.hpp>
+#include <networkprotocoldsl/operation/unarycallback.hpp>
+
 namespace networkprotocoldsl {
-
-/**
- * The operation concept allows type erasure in some places where we use
- * std::visit.
- */
-template <typename OT>
-concept OperationConcept = requires(OT op, OT::Arguments args) {
-  {
-    std::tuple_size<typename OT::Arguments>::value
-    } -> std::convertible_to<std::size_t>;
-  { op(args) } -> std::convertible_to<Value>;
-  { op.callback_key() } -> std::convertible_to<std::optional<std::string>>;
-};
-
-namespace operation {
-
-/**
- * An int32_t literal type.
- */
-class Int32Literal {
-  int32_t int32_v;
-
-public:
-  using Arguments = std::tuple<>;
-  Int32Literal(int32_t v) : int32_v(v) {}
-  Value operator()(Arguments a) const { return int32_v; }
-  std::optional<std::string> callback_key() const { return std::nullopt; }
-};
-static_assert(OperationConcept<Int32Literal>);
-
-/**
- * Add two values.
- */
-class Add {
-public:
-  using Arguments = std::tuple<Value, Value>;
-  Value operator()(Arguments a) const {
-    return std::visit(
-        [&a](int32_t v1) -> Value {
-          return std::visit([&v1](int32_t v2) -> Value { return v1 + v2; },
-                            std::get<1>(a));
-        },
-        std::get<0>(a));
-  }
-  std::optional<std::string> callback_key() const { return std::nullopt; }
-};
-static_assert(OperationConcept<Add>);
-
-class UnaryCallback {
-  const std::string key;
-
-public:
-  UnaryCallback(std::string c) : key(c) {}
-  using Arguments = std::tuple<Value>;
-  Value operator()(Arguments a) const { return 0; }
-  std::optional<std::string> callback_key() const { return key; }
-};
-
-}; // namespace operation
 
 /**
  * Operation is a variant of all known operation types.
@@ -77,8 +17,9 @@ public:
  * operations that may happen in the execution of the interpreted
  * code.
  */
-using Operation = std::variant<operation::Int32Literal, operation::Add,
-                               operation::UnaryCallback>;
+using Operation =
+    std::variant<operation::Int32Literal, operation::Add,
+                 operation::UnaryCallback, operation::ReadInt32Native>;
 
 } // namespace networkprotocoldsl
 

--- a/src/networkprotocoldsl/operation/add.cpp
+++ b/src/networkprotocoldsl/operation/add.cpp
@@ -1,0 +1,14 @@
+#include <networkprotocoldsl/operation/add.hpp>
+
+namespace networkprotocoldsl::operation {
+
+Value Add::operator()(Arguments a) const {
+  return std::visit(
+      [&a](int32_t v1) -> Value {
+        return std::visit([&v1](int32_t v2) -> Value { return v1 + v2; },
+                          std::get<1>(a));
+      },
+      std::get<0>(a));
+}
+
+} // namespace networkprotocoldsl::operation

--- a/src/networkprotocoldsl/operation/add.hpp
+++ b/src/networkprotocoldsl/operation/add.hpp
@@ -1,0 +1,31 @@
+#ifndef NETWORKPROTOCOLDSL_OPERATION_ADD_HPP
+#define NETWORKPROTOCOLDSL_OPERATION_ADD_HPP
+
+#include <networkprotocoldsl/operationconcepts.hpp>
+#include <networkprotocoldsl/value.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <variant>
+
+namespace networkprotocoldsl {
+
+namespace operation {
+
+/**
+ * Add two values.
+ */
+class Add {
+public:
+  using Arguments = std::tuple<Value, Value>;
+  Value operator()(Arguments a) const;
+};
+static_assert(InterpretedOperationConcept<Add>);
+
+}; // namespace operation
+
+} // namespace networkprotocoldsl
+
+#endif // NETWORKPROTOCOLDSL_OPERATION_HPP

--- a/src/networkprotocoldsl/operation/int32literal.cpp
+++ b/src/networkprotocoldsl/operation/int32literal.cpp
@@ -1,0 +1,1 @@
+#include <networkprotocoldsl/operation/int32literal.hpp>

--- a/src/networkprotocoldsl/operation/int32literal.hpp
+++ b/src/networkprotocoldsl/operation/int32literal.hpp
@@ -1,0 +1,34 @@
+#ifndef NETWORKPROTOCOLDSL_OPERATION_INT32LITERAL_HPP
+#define NETWORKPROTOCOLDSL_OPERATION_INT32LITERAL_HPP
+
+#include <networkprotocoldsl/operationconcepts.hpp>
+#include <networkprotocoldsl/value.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <variant>
+
+namespace networkprotocoldsl {
+
+namespace operation {
+
+/**
+ * An int32_t literal type.
+ */
+class Int32Literal {
+  int32_t int32_v;
+
+public:
+  using Arguments = std::tuple<>;
+  Int32Literal(int32_t v) : int32_v(v) {}
+  Value operator()(Arguments a) const { return int32_v; }
+};
+static_assert(InterpretedOperationConcept<Int32Literal>);
+
+}; // namespace operation
+
+} // namespace networkprotocoldsl
+
+#endif // NETWORKPROTOCOLDSL_OPERATION_HPP

--- a/src/networkprotocoldsl/operation/readint32native.cpp
+++ b/src/networkprotocoldsl/operation/readint32native.cpp
@@ -1,0 +1,18 @@
+#include <networkprotocoldsl/operation/readint32native.hpp>
+
+namespace networkprotocoldsl::operation {
+
+OperationResult ReadInt32Native::operator()(InputOutputOperationContext &ctx,
+                                            Arguments a) const {
+  return ReasonForBlockedOperation::WaitingForRead;
+}
+
+size_t ReadInt32Native::handle_read(InputOutputOperationContext &ctx) const {
+  return 0;
+}
+
+size_t ReadInt32Native::handle_write(InputOutputOperationContext &ctx) const {
+  return 0;
+}
+
+} // namespace networkprotocoldsl::operation

--- a/src/networkprotocoldsl/operation/readint32native.hpp
+++ b/src/networkprotocoldsl/operation/readint32native.hpp
@@ -1,0 +1,33 @@
+#ifndef NETWORKPROTOCOLDSL_OPERATION_READINT32NATIVE_HPP
+#define NETWORKPROTOCOLDSL_OPERATION_READINT32NATIVE_HPP
+
+#include <networkprotocoldsl/operationconcepts.hpp>
+#include <networkprotocoldsl/value.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <variant>
+
+namespace networkprotocoldsl {
+
+namespace operation {
+
+class ReadInt32Native {
+public:
+  using Arguments = std::tuple<>;
+  ReadInt32Native() {}
+
+  OperationResult operator()(InputOutputOperationContext &ctx,
+                             Arguments a) const;
+  size_t handle_read(InputOutputOperationContext &ctx) const;
+  size_t handle_write(InputOutputOperationContext &ctx) const;
+};
+static_assert(InputOutputOperationConcept<ReadInt32Native>);
+
+} // namespace operation
+
+} // namespace networkprotocoldsl
+
+#endif // NETWORKPROTOCOLDSL_OPERATION_HPP

--- a/src/networkprotocoldsl/operation/unarycallback.cpp
+++ b/src/networkprotocoldsl/operation/unarycallback.cpp
@@ -1,0 +1,29 @@
+#include <networkprotocoldsl/operation/unarycallback.hpp>
+
+namespace networkprotocoldsl::operation {
+
+OperationResult UnaryCallback::operator()(CallbackOperationContext &ctx,
+                                          Arguments a) const {
+  if (!ctx.callback_called) {
+    return ReasonForBlockedOperation::WaitingForCallback;
+  } else if (!ctx.value.has_value()) {
+    return ReasonForBlockedOperation::WaitingCallbackData;
+  } else {
+    return *ctx.value;
+  }
+}
+
+std::string UnaryCallback::callback_key(CallbackOperationContext &ctx) const {
+  return key;
+}
+
+void UnaryCallback::set_callback_return(CallbackOperationContext &ctx,
+                                        Value v) const {
+  ctx.value = v;
+}
+
+void UnaryCallback::set_callback_called(CallbackOperationContext &ctx) const {
+  ctx.callback_called = true;
+}
+
+} // namespace networkprotocoldsl::operation

--- a/src/networkprotocoldsl/operation/unarycallback.hpp
+++ b/src/networkprotocoldsl/operation/unarycallback.hpp
@@ -1,0 +1,34 @@
+#ifndef NETWORKPROTOCOLDSL_OPERATION_UNARYCALLBACK_HPP
+#define NETWORKPROTOCOLDSL_OPERATION_UNARYCALLBACK_HPP
+
+#include <networkprotocoldsl/operationconcepts.hpp>
+#include <networkprotocoldsl/value.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <variant>
+
+namespace networkprotocoldsl {
+
+namespace operation {
+
+class UnaryCallback {
+  const std::string key;
+
+public:
+  UnaryCallback(std::string c) : key(c) {}
+  using Arguments = std::tuple<Value>;
+  OperationResult operator()(CallbackOperationContext &ctx, Arguments a) const;
+  std::string callback_key(CallbackOperationContext &ctx) const;
+  void set_callback_return(CallbackOperationContext &ctx, Value v) const;
+  void set_callback_called(CallbackOperationContext &ctx) const;
+};
+static_assert(CallbackOperationConcept<UnaryCallback>);
+
+}; // namespace operation
+
+} // namespace networkprotocoldsl
+
+#endif // NETWORKPROTOCOLDSL_OPERATION_HPP

--- a/src/networkprotocoldsl/operationconcepts.cpp
+++ b/src/networkprotocoldsl/operationconcepts.cpp
@@ -1,0 +1,1 @@
+#include <networkprotocoldsl/operationconcepts.hpp>

--- a/src/networkprotocoldsl/operationconcepts.hpp
+++ b/src/networkprotocoldsl/operationconcepts.hpp
@@ -1,0 +1,98 @@
+#ifndef INCLUDED_NETWORKPROTOCOLDSL_OPERATIONCONCEPTS_HPP
+#define INCLUDED_NETWORKPROTOCOLDSL_OPERATIONCONCEPTS_HPP
+
+#include <networkprotocoldsl/value.hpp>
+
+#include <optional>
+#include <tuple>
+#include <variant>
+
+namespace networkprotocoldsl {
+
+/**
+ * This represents the reasons why an operation may not be complete
+ * because of an external reason.
+ */
+enum class ReasonForBlockedOperation {
+  WaitingForCallback,
+  WaitingCallbackData,
+  WaitingForRead,
+  WaitingForWrite
+};
+
+/**
+ * The OperationResult type informs whether the operation coudl have
+ * been executed, or if it had to be suspeneded because of some
+ * specific status.
+ */
+using OperationResult = std::variant<Value, ReasonForBlockedOperation>;
+
+/**
+ * The Operation Concept covers the necessary interface to discover
+ * whether the stack machine has processed enough arguments for the
+ * operation to be executed.
+ */
+template <typename OT>
+concept OperationConcept = requires(OT op, typename OT::Arguments args) {
+  {
+    std::tuple_size<typename OT::Arguments>::value
+    } -> std::convertible_to<std::size_t>;
+};
+
+/**
+ * Interpreted operations cannot block, and must always return a value.
+ */
+template <typename OT>
+concept InterpretedOperationConcept = requires(OT op,
+                                               typename OT::Arguments args) {
+  {OperationConcept<OT>};
+  { op(args) } -> std::convertible_to<Value>;
+};
+
+/**
+ * Callback operations have a specific context type
+ */
+struct CallbackOperationContext {
+  std::optional<Value> value;
+  bool callback_called = false;
+};
+
+/**
+ * The callback operation concept offers the additional interfaces for
+ * handling the status of the callback.
+ */
+template <typename OT>
+concept CallbackOperationConcept = requires(OT op, typename OT::Arguments args,
+                                            Value v,
+                                            CallbackOperationContext ctx) {
+  {OperationConcept<OT>};
+  { op.callback_key(ctx) } -> std::convertible_to<std::string>;
+  { op(ctx, args) } -> std::convertible_to<OperationResult>;
+  {op.set_callback_called(ctx)};
+  {op.set_callback_return(ctx, v)};
+};
+
+/**
+ * IO operations need additional context for accumulating the data
+ * they need to execute.
+ */
+struct InputOutputOperationContext {
+  std::string buffer;
+};
+
+/**
+ * The callback operation concept offers the additional interfaces for
+ * handling IO buffers.
+ */
+template <typename OT>
+concept InputOutputOperationConcept = requires(
+    OT op, typename OT::Arguments args, InputOutputOperationContext ctx) {
+  {OperationConcept<OT>};
+  { op(ctx, args) } -> std::convertible_to<OperationResult>;
+  { op.handle_read(ctx) } -> std::convertible_to<std::size_t>;
+  { op.handle_write(ctx) } -> std::convertible_to<std::size_t>;
+};
+
+} // namespace networkprotocoldsl
+
+#endif


### PR DESCRIPTION
Introduce three different types of operations, implemented as concepts that can be used to dispatch the operation variant according to the specific interface.

Also perform a general reorganization of the code to better isolate implementation details out of the header files.