### PR TITLE
Introduce handling of eof

### DIFF
--- a/src/networkprotocoldsl/continuation.cpp
+++ b/src/networkprotocoldsl/continuation.cpp
@@ -86,6 +86,13 @@ static size_t _handle_read(Continuation *c, const O &o, std::string_view s) {
       std::get<InputOutputOperationContext>(c->top().get_context()), s);
 }
 
+template <typename O> static void _handle_eof(Continuation *c, const O &o) {}
+
+template <InputOutputOperationConcept O>
+static void _handle_eof(Continuation *c, const O &o) {
+  o.handle_eof(std::get<InputOutputOperationContext>(c->top().get_context()));
+}
+
 template <typename O>
 static std::string_view _get_write_buffer(Continuation *c, const O &o) {
   return std::string_view();
@@ -214,6 +221,11 @@ void Continuation::set_callable_invoked() {
 void Continuation::set_callable_return(Value v) {
   result = v;
   std::visit([this, &v](auto &o) { _set_callable_return(this, o, v); },
+             stack.top().get_operation());
+}
+
+void Continuation::handle_eof() {
+  std::visit([this](auto &o) { _handle_eof(this, o); },
              stack.top().get_operation());
 }
 

--- a/src/networkprotocoldsl/continuation.hpp
+++ b/src/networkprotocoldsl/continuation.hpp
@@ -63,6 +63,8 @@ public:
   std::string_view get_write_buffer();
 
   size_t handle_write(size_t s);
+
+  void handle_eof();
 };
 
 } // namespace networkprotocoldsl

--- a/src/networkprotocoldsl/interpreter.hpp
+++ b/src/networkprotocoldsl/interpreter.hpp
@@ -104,6 +104,8 @@ public:
   size_t handle_write(size_t s) {
     return continuation_stack.top().handle_write(s);
   }
+
+  void handle_eof() { return continuation_stack.top().handle_eof(); }
 };
 
 } // namespace networkprotocoldsl

--- a/src/networkprotocoldsl/operation/readint32native.cpp
+++ b/src/networkprotocoldsl/operation/readint32native.cpp
@@ -8,6 +8,8 @@ namespace networkprotocoldsl::operation {
 OperationResult ReadInt32Native::operator()(InputOutputOperationContext &ctx,
                                             Arguments a) const {
   if (ctx.buffer.length() < 4) {
+    if (ctx.eof)
+      return value::RuntimeError::ProtocolMismatchError;
     return ReasonForBlockedOperation::WaitingForRead;
   } else {
     int v = 0;
@@ -31,6 +33,10 @@ size_t ReadInt32Native::handle_read(InputOutputOperationContext &ctx,
   } else {
     return 0;
   }
+}
+
+void ReadInt32Native::handle_eof(InputOutputOperationContext &ctx) const {
+  ctx.eof = true;
 }
 
 std::string_view

--- a/src/networkprotocoldsl/operation/readint32native.hpp
+++ b/src/networkprotocoldsl/operation/readint32native.hpp
@@ -24,7 +24,7 @@ public:
                              Arguments a) const;
   size_t handle_read(InputOutputOperationContext &ctx,
                      std::string_view in) const;
-
+  void handle_eof(InputOutputOperationContext &ctx) const;
   std::string_view get_write_buffer(InputOutputOperationContext &ctx) const;
 
   size_t handle_write(InputOutputOperationContext &ctx, size_t s) const;

--- a/src/networkprotocoldsl/operation/readintfromascii.cpp
+++ b/src/networkprotocoldsl/operation/readintfromascii.cpp
@@ -28,6 +28,8 @@ OperationResult ReadIntFromAscii::operator()(InputOutputOperationContext &ctx,
         }
       }
     }
+  } else if (ctx.eof) {
+    return value::RuntimeError::ProtocolMismatchError;
   } else {
     return ReasonForBlockedOperation::WaitingForRead;
   }
@@ -47,6 +49,10 @@ size_t ReadIntFromAscii::handle_read(InputOutputOperationContext &ctx,
   } else {
     return 0;
   }
+}
+
+void ReadIntFromAscii::handle_eof(InputOutputOperationContext &ctx) const {
+  ctx.eof = true;
 }
 
 std::string_view

--- a/src/networkprotocoldsl/operation/readintfromascii.hpp
+++ b/src/networkprotocoldsl/operation/readintfromascii.hpp
@@ -25,6 +25,7 @@ public:
                              Arguments a) const;
   size_t handle_read(InputOutputOperationContext &ctx,
                      std::string_view in) const;
+  void handle_eof(InputOutputOperationContext &ctx) const;
 
   std::string_view get_write_buffer(InputOutputOperationContext &ctx) const;
 

--- a/src/networkprotocoldsl/operation/readoctetsuntilterminator.cpp
+++ b/src/networkprotocoldsl/operation/readoctetsuntilterminator.cpp
@@ -12,6 +12,8 @@ ReadOctetsUntilTerminator::operator()(InputOutputOperationContext &ctx,
                                       Arguments a) const {
   if (ctx.ready) {
     return value::Octets{std::make_shared<const std::string>(ctx.buffer)};
+  } else if (ctx.eof) {
+    return value::RuntimeError::ProtocolMismatchError;
   } else {
     return ReasonForBlockedOperation::WaitingForRead;
   }
@@ -27,6 +29,11 @@ size_t ReadOctetsUntilTerminator::handle_read(InputOutputOperationContext &ctx,
     ctx.ready = true;
     return pos + terminator.size();
   }
+}
+
+void ReadOctetsUntilTerminator::handle_eof(
+    InputOutputOperationContext &ctx) const {
+  ctx.eof = true;
 }
 
 std::string_view ReadOctetsUntilTerminator::get_write_buffer(

--- a/src/networkprotocoldsl/operation/readoctetsuntilterminator.hpp
+++ b/src/networkprotocoldsl/operation/readoctetsuntilterminator.hpp
@@ -28,6 +28,7 @@ public:
                      std::string_view in) const;
 
   std::string_view get_write_buffer(InputOutputOperationContext &ctx) const;
+  void handle_eof(InputOutputOperationContext &ctx) const;
 
   size_t handle_write(InputOutputOperationContext &ctx, size_t s) const;
 };

--- a/src/networkprotocoldsl/operation/readstaticoctets.cpp
+++ b/src/networkprotocoldsl/operation/readstaticoctets.cpp
@@ -8,7 +8,11 @@ namespace networkprotocoldsl::operation {
 OperationResult ReadStaticOctets::operator()(InputOutputOperationContext &ctx,
                                              Arguments a) const {
   if (ctx.buffer.length() < contents.length()) {
-    return ReasonForBlockedOperation::WaitingForRead;
+    if (ctx.eof) {
+      return value::RuntimeError::ProtocolMismatchError;
+    } else {
+      return ReasonForBlockedOperation::WaitingForRead;
+    }
   } else {
     if (strncmp(ctx.buffer.c_str(), contents.c_str(), contents.length()) == 0) {
       return true;
@@ -26,6 +30,10 @@ size_t ReadStaticOctets::handle_read(InputOutputOperationContext &ctx,
     ctx.buffer = std::string(in.begin(), contents.length());
     return contents.length();
   }
+}
+
+void ReadStaticOctets::handle_eof(InputOutputOperationContext &ctx) const {
+  ctx.eof = true;
 }
 
 std::string_view

--- a/src/networkprotocoldsl/operation/readstaticoctets.hpp
+++ b/src/networkprotocoldsl/operation/readstaticoctets.hpp
@@ -28,6 +28,7 @@ public:
                      std::string_view in) const;
 
   std::string_view get_write_buffer(InputOutputOperationContext &ctx) const;
+  void handle_eof(InputOutputOperationContext &ctx) const;
 
   size_t handle_write(InputOutputOperationContext &ctx, size_t s) const;
 };

--- a/src/networkprotocoldsl/operation/terminatelistifreadahead.cpp
+++ b/src/networkprotocoldsl/operation/terminatelistifreadahead.cpp
@@ -15,7 +15,11 @@ TerminateListIfReadAhead::operator()(InputOutputOperationContext &ctx,
     // can just finish the operator.
     if (ctx.buffer == terminator.substr(0, ctx.buffer.length())) {
       // we match so far, but we can't be sure yet.
-      return ReasonForBlockedOperation::WaitingForRead;
+      if (ctx.eof) {
+        return value::RuntimeError::ProtocolMismatchError;
+      } else {
+        return ReasonForBlockedOperation::WaitingForRead;
+      }
     } else {
       // we already know it doesn't match. Return a value.
       return false;
@@ -45,6 +49,11 @@ size_t TerminateListIfReadAhead::handle_read(InputOutputOperationContext &ctx,
 std::string_view TerminateListIfReadAhead::get_write_buffer(
     InputOutputOperationContext &ctx) const {
   return ctx.buffer;
+}
+
+void TerminateListIfReadAhead::handle_eof(
+    InputOutputOperationContext &ctx) const {
+  ctx.eof = true;
 }
 
 size_t TerminateListIfReadAhead::handle_write(InputOutputOperationContext &ctx,

--- a/src/networkprotocoldsl/operation/terminatelistifreadahead.hpp
+++ b/src/networkprotocoldsl/operation/terminatelistifreadahead.hpp
@@ -21,6 +21,7 @@ public:
                      std::string_view in) const;
 
   std::string_view get_write_buffer(InputOutputOperationContext &ctx) const;
+  void handle_eof(InputOutputOperationContext &ctx) const;
 
   size_t handle_write(InputOutputOperationContext &ctx, size_t s) const;
 };

--- a/src/networkprotocoldsl/operation/writeint32native.cpp
+++ b/src/networkprotocoldsl/operation/writeint32native.cpp
@@ -17,7 +17,11 @@ OperationResult WriteInt32Native::operator()(InputOutputOperationContext &ctx,
     ctx.it = ctx.buffer.begin();
   }
   if (ctx.it != ctx.buffer.end()) {
-    return ReasonForBlockedOperation::WaitingForWrite;
+    if (ctx.eof) {
+      return value::RuntimeError::ProtocolMismatchError;
+    } else {
+      return ReasonForBlockedOperation::WaitingForWrite;
+    }
   } else {
     return 0;
   }
@@ -31,6 +35,10 @@ size_t WriteInt32Native::handle_read(InputOutputOperationContext &ctx,
 std::string_view
 WriteInt32Native::get_write_buffer(InputOutputOperationContext &ctx) const {
   return std::string_view(ctx.it, ctx.buffer.end());
+}
+
+void WriteInt32Native::handle_eof(InputOutputOperationContext &ctx) const {
+  ctx.eof = true;
 }
 
 size_t WriteInt32Native::handle_write(InputOutputOperationContext &ctx,

--- a/src/networkprotocoldsl/operation/writeint32native.hpp
+++ b/src/networkprotocoldsl/operation/writeint32native.hpp
@@ -26,6 +26,7 @@ public:
                      std::string_view in) const;
 
   std::string_view get_write_buffer(InputOutputOperationContext &ctx) const;
+  void handle_eof(InputOutputOperationContext &ctx) const;
 
   size_t handle_write(InputOutputOperationContext &ctx, size_t s) const;
 };

--- a/src/networkprotocoldsl/operation/writeoctets.cpp
+++ b/src/networkprotocoldsl/operation/writeoctets.cpp
@@ -15,7 +15,11 @@ static OperationResult _execute_operation(InputOutputOperationContext &ctx,
     ctx.it = ctx.buffer.begin();
   }
   if (ctx.it != ctx.buffer.end()) {
-    return ReasonForBlockedOperation::WaitingForWrite;
+    if (ctx.eof) {
+      return value::RuntimeError::ProtocolMismatchError;
+    } else {
+      return ReasonForBlockedOperation::WaitingForWrite;
+    }
   } else {
     return 0;
   }
@@ -40,6 +44,10 @@ OperationResult WriteOctets::operator()(InputOutputOperationContext &ctx,
                                         Arguments a) const {
   return std::visit([&ctx](auto arg) { return _execute_operation(ctx, arg); },
                     std::get<0>(a));
+}
+
+void WriteOctets::handle_eof(InputOutputOperationContext &ctx) const {
+  ctx.eof = true;
 }
 
 size_t WriteOctets::handle_read(InputOutputOperationContext &ctx,

--- a/src/networkprotocoldsl/operation/writeoctets.hpp
+++ b/src/networkprotocoldsl/operation/writeoctets.hpp
@@ -26,6 +26,7 @@ public:
                      std::string_view in) const;
 
   std::string_view get_write_buffer(InputOutputOperationContext &ctx) const;
+  void handle_eof(InputOutputOperationContext &ctx) const;
 
   size_t handle_write(InputOutputOperationContext &ctx, size_t s) const;
 };

--- a/src/networkprotocoldsl/operation/writestaticoctets.cpp
+++ b/src/networkprotocoldsl/operation/writestaticoctets.cpp
@@ -13,7 +13,11 @@ OperationResult WriteStaticOctets::operator()(InputOutputOperationContext &ctx,
     ctx.it = ctx.buffer.begin();
   }
   if (ctx.it != ctx.buffer.end()) {
-    return ReasonForBlockedOperation::WaitingForWrite;
+    if (ctx.eof) {
+      return value::RuntimeError::ProtocolMismatchError;
+    } else {
+      return ReasonForBlockedOperation::WaitingForWrite;
+    }
   } else {
     return 0;
   }
@@ -22,6 +26,10 @@ OperationResult WriteStaticOctets::operator()(InputOutputOperationContext &ctx,
 size_t WriteStaticOctets::handle_read(InputOutputOperationContext &ctx,
                                       std::string_view in) const {
   return 0;
+}
+
+void WriteStaticOctets::handle_eof(InputOutputOperationContext &ctx) const {
+  ctx.eof = true;
 }
 
 std::string_view

--- a/src/networkprotocoldsl/operation/writestaticoctets.hpp
+++ b/src/networkprotocoldsl/operation/writestaticoctets.hpp
@@ -28,6 +28,7 @@ public:
                      std::string_view in) const;
 
   std::string_view get_write_buffer(InputOutputOperationContext &ctx) const;
+  void handle_eof(InputOutputOperationContext &ctx) const;
 
   size_t handle_write(InputOutputOperationContext &ctx, size_t s) const;
 };

--- a/src/networkprotocoldsl/operationconcepts.hpp
+++ b/src/networkprotocoldsl/operationconcepts.hpp
@@ -92,6 +92,7 @@ struct InputOutputOperationContext {
   std::string buffer;
   std::string::iterator it;
   bool ready;
+  bool eof;
 };
 
 /**
@@ -108,6 +109,7 @@ concept InputOutputOperationConcept = requires(OT op,
   { op.handle_read(ctx, sv) } -> std::convertible_to<std::size_t>;
   { op.get_write_buffer(ctx) } -> std::convertible_to<std::string_view>;
   {op.handle_write(ctx, s)};
+  {op.handle_eof(ctx)};
 };
 
 /**


### PR DESCRIPTION
The examples up to this point were able to ignore the eof case, however, as I am implementing a real interpreter now, it is necessary for the interpreter to be able to shut-down correctly and handle network issues.