### PR TITLE
Small fixes after some more experimentation

### DIFF
--- a/src/networkprotocoldsl/interpretedprogram.cpp
+++ b/src/networkprotocoldsl/interpretedprogram.cpp
@@ -1,32 +1,29 @@
-#include <networkprotocoldsl/interpretedprogram.hpp>
-
+#include <fstream>
 #include <networkprotocoldsl/generate.hpp>
+#include <networkprotocoldsl/interpretedprogram.hpp>
 #include <networkprotocoldsl/lexer/tokenize.hpp>
 #include <networkprotocoldsl/parser/parse.hpp>
 #include <networkprotocoldsl/sema/analyze.hpp>
 
-#include <fstream>
-
 namespace networkprotocoldsl {
 
-std::optional<std::shared_ptr<const sema::ast::Protocol>>
-parse_protocol(const std::string &sf) {
-  auto fstream = std::ifstream(sf);
-  auto content = std::string(std::istreambuf_iterator<char>(fstream),
-                             std::istreambuf_iterator<char>());
-  auto maybe_tokens = lexer::tokenize(content);
+// New helper to parse protocol directly from source code.
+static std::optional<std::shared_ptr<const sema::ast::Protocol>>
+parse_protocol_from_source(const std::string &source) {
+  auto maybe_tokens = lexer::tokenize(source);
   if (!maybe_tokens.has_value())
     return std::nullopt;
-  std::vector<lexer::Token> &tokens = maybe_tokens.value();
+  std::vector<lexer::Token> tokens = maybe_tokens.value();
   auto maybe_ast = parser::parse(tokens);
   if (!maybe_ast.has_value())
     return std::nullopt;
   return sema::analyze(maybe_ast.value());
 }
 
+// New implementation: generate client from source code contents.
 std::optional<InterpretedProgram>
-InterpretedProgram::generate_client(const std::string &sf) {
-  auto maybe_protocol = parse_protocol(sf);
+InterpretedProgram::generate_client_from_source(const std::string &source) {
+  auto maybe_protocol = parse_protocol_from_source(source);
   if (!maybe_protocol.has_value())
     return std::nullopt;
   auto maybe_client = generate::client(maybe_protocol.value());
@@ -35,15 +32,38 @@ InterpretedProgram::generate_client(const std::string &sf) {
   return InterpretedProgram(maybe_client.value());
 }
 
+// New implementation: generate server from source code contents.
 std::optional<InterpretedProgram>
-InterpretedProgram::generate_server(const std::string &sf) {
-  auto maybe_protocol = parse_protocol(sf);
+InterpretedProgram::generate_server_from_source(const std::string &source) {
+  auto maybe_protocol = parse_protocol_from_source(source);
   if (!maybe_protocol.has_value())
     return std::nullopt;
   auto maybe_server = generate::server(maybe_protocol.value());
   if (!maybe_server.has_value())
     return std::nullopt;
   return InterpretedProgram(maybe_server.value());
+}
+
+std::optional<InterpretedProgram>
+InterpretedProgram::generate_client(const std::string &sf) {
+  // Simplify: read file contents and delegate to generate_client_from_source
+  std::ifstream fstream(sf);
+  if (!fstream)
+    return std::nullopt;
+  std::string content((std::istreambuf_iterator<char>(fstream)),
+                      std::istreambuf_iterator<char>());
+  return generate_client_from_source(content);
+}
+
+std::optional<InterpretedProgram>
+InterpretedProgram::generate_server(const std::string &sf) {
+  // Simplify: read file contents and delegate to generate_server_from_source
+  std::ifstream fstream(sf);
+  if (!fstream)
+    return std::nullopt;
+  std::string content((std::istreambuf_iterator<char>(fstream)),
+                      std::istreambuf_iterator<char>());
+  return generate_server_from_source(content);
 }
 
 } // namespace networkprotocoldsl

--- a/src/networkprotocoldsl/interpretedprogram.hpp
+++ b/src/networkprotocoldsl/interpretedprogram.hpp
@@ -29,6 +29,12 @@ public:
   static std::optional<InterpretedProgram>
   generate_server(const std::string &sf);
 
+  // New interfaces accepting source code contents directly.
+  static std::optional<InterpretedProgram>
+  generate_client_from_source(const std::string &source);
+  static std::optional<InterpretedProgram>
+  generate_server_from_source(const std::string &source);
+
   /**
    * Skips the parsing and receives an optree instead.
    */

--- a/src/networkprotocoldsl/operation/statemachineoperation.cpp
+++ b/src/networkprotocoldsl/operation/statemachineoperation.cpp
@@ -47,7 +47,7 @@ _extract_arguments(const std::vector<std::string> &names,
   for (const auto &arg_name : names) {
     auto it = d.members->find(arg_name);
     if (it == d.members->end()) {
-      return std::nullopt;
+      args->push_back(false);
     } else {
       args->push_back(it->second);
     }

--- a/src/networkprotocoldsl/parser/parse.cpp
+++ b/src/networkprotocoldsl/parser/parse.cpp
@@ -1,3 +1,4 @@
+#include <iostream> // Add this include for std::cerr
 #include <networkprotocoldsl/parser/grammar/protocoldescription.hpp>
 #include <networkprotocoldsl/parser/parse.hpp>
 
@@ -8,6 +9,24 @@ parse(const std::vector<lexer::Token> &tokens) {
   auto result =
       grammar::ProtocolDescription::parse(tokens.cbegin(), tokens.cend());
   if (result.begin != tokens.cend()) {
+    // Define a visitor lambda that uses stringify if available.
+    auto tokenToStringVisitor = [](const auto &token) -> std::string {
+      if constexpr (requires { token.stringify(); }) {
+        return token.stringify();
+      } else {
+        return "<NOT_STRINGIFIABLE>";
+      }
+    };
+    // Print to stderr the next 10 tokens starting at the current position.
+    std::cerr << "Parsing stopped. Next tokens: ";
+    auto it = result.begin;
+    int count = 0;
+    while (it != tokens.cend() && count < 10) {
+      std::cerr << std::visit(tokenToStringVisitor, *it) << " ";
+      ++it;
+      ++count;
+    }
+    std::cerr << std::endl;
     return std::nullopt;
   }
   if (result.node.has_value()) {


### PR DESCRIPTION
The changes here are:

 1. Read transitions also need to pass the data forward, that way we can keep context across messages
 2. Give an error message explaining where the parse failed.
 3. Support parsing source code directly, instead of just via a file name