### PR TITLE
Fix the Dockerfile and src/networkprotocoldsl/operation/readintfromascii.cpp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN apt-get -y update && apt-get -y dist-upgrade && apt-get install -y \
         build-essential \
         g++ \
         libgtest-dev \
+        libuv1-dev \
+        git     \
+        libcli11-dev \
         && apt-get clean
 
 COPY . src/

--- a/src/networkprotocoldsl/operation/readintfromascii.cpp
+++ b/src/networkprotocoldsl/operation/readintfromascii.cpp
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <memory>
 #include <stdlib.h>
+#include <climits>
 #include <string_view>
 
 namespace networkprotocoldsl::operation {


### PR DESCRIPTION
This changelist fixes the dockerfile to include:
```
libuv1-dev
git
libcli11-dev
```

Also readintfromascii.cpp needs `climits` include file.