### PR TITLE
Escape sequence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,8 @@ add_library(
     src/networkprotocoldsl/operation/writeint32native.hpp
     src/networkprotocoldsl/operation/writeoctets.cpp
     src/networkprotocoldsl/operation/writeoctets.hpp
+    src/networkprotocoldsl/operation/writeoctetswithescape.cpp
+    src/networkprotocoldsl/operation/writeoctetswithescape.hpp
     src/networkprotocoldsl/operation/writestaticoctets.cpp
     src/networkprotocoldsl/operation/writestaticoctets.hpp
     src/networkprotocoldsl/operation/lexicalpadasdict.cpp

--- a/examples/smtpserver/smtp.networkprotocoldsl
+++ b/examples/smtpserver/smtp.networkprotocoldsl
@@ -274,8 +274,10 @@ message "SMTP DATA Content" {
         content: str<encoding=Ascii7Bit, sizing=Dynamic, max_length=65536>; 
     } 
     parts { 
-        tokens { content } 
-        terminator { "\r\n.\r\n" }  
+        // SMTP dot-stuffing: lines starting with "." are escaped as ".."
+        // The terminator is "\r\n.\r\n" (a line with just a dot)
+        // If the content has "\r\n." it becomes "\r\n.." on wire
+        tokens<terminator="\r\n.\r\n", escape=replace<"\r\n.", "\r\n..">> { content }
     } 
 }
 

--- a/notes/grammar.txt
+++ b/notes/grammar.txt
@@ -33,15 +33,28 @@
    <IdentifierReference> |
    <StringLiteral>
 
-// TokenSequenceOption uses identifier=string pattern (like TypeParameter)
+// TokenSequenceOption uses identifier=value pattern (like TypeParameter)
 // Valid identifiers are "terminator" and "escape" (contextual, not keywords)
-// - terminator: the string that ends this token sequence
-// - escape: a sequence that, when found, continues reading instead of terminating
-//           (used for HTTP/1.1 header continuation lines: CRLF followed by space)
+// - terminator: the string that ends this token sequence (value is StringLiteral)
+// - escape: defines character replacement for escape sequences
+//           value is replace<"char", "sequence"> meaning:
+//           - when parsing: replace "sequence" with "char" in captured value
+//           - when serializing: replace "char" with "sequence" in output
+//           Example: escape=replace<"\n", "\r\n "> for HTTP/1.1 header continuation
+<EscapeReplacement> ::=
+   token::Identifier  // must be "replace"
+   token::punctuation::AngleBracketOpen
+   <StringLiteral>    // the character to represent (e.g., "\n")
+   token::punctuation::Comma
+   <StringLiteral>    // the escape sequence on the wire (e.g., "\r\n ")
+   token::punctuation::AngleBracketClose
+<TokenSequenceOptionValue> ::=
+   <StringLiteral> |
+   <EscapeReplacement>
 <TokenSequenceOption> ::=
    token::Identifier  // "terminator" or "escape"
    token::punctuation::Equals
-   <StringLiteral>
+   <TokenSequenceOptionValue>
 <TokenSequenceOptions> ::=
    token::punctuation::AngleBracketOpen
    <TokenSequenceOption>

--- a/notes/grammar.txt
+++ b/notes/grammar.txt
@@ -32,24 +32,54 @@
 <TokenPart> ::=
    <IdentifierReference> |
    <StringLiteral>
+
+// TokenSequenceOption uses identifier=string pattern (like TypeParameter)
+// Valid identifiers are "terminator" and "escape" (contextual, not keywords)
+// - terminator: the string that ends this token sequence
+// - escape: a sequence that, when found, continues reading instead of terminating
+//           (used for HTTP/1.1 header continuation lines: CRLF followed by space)
+<TokenSequenceOption> ::=
+   token::Identifier  // "terminator" or "escape"
+   token::punctuation::Equals
+   <StringLiteral>
+<TokenSequenceOptions> ::=
+   token::punctuation::AngleBracketOpen
+   <TokenSequenceOption>
+   (token::punctuation::Comma <TokenSequenceOption>)*
+   token::punctuation::AngleBracketClose
+
 <TokenSequence> ::=
-   <IdentifierReference> // identifier name must be "tokens"
+   token::keyword::Tokens
+   <TokenSequenceOptions>?
    token::punctuation::CurlyBraceOpen
    <TokenPart>*
    token::punctuation::CurlyBraceClose
+
+// Legacy terminator syntax (for backward compatibility)
 <Terminator> ::=
    <IdentifierReference> // identifier name must be "terminator"
    token::punctuation::CurlyBraceOpen
    <StringLiteral>
-   token::punctuation::CurlyBraceClose // Added missing closing curly brace
+   token::punctuation::CurlyBraceClose
+
+// ForLoopOptions uses the same pattern as TokenSequenceOptions
+// Valid identifier is "terminator" (contextual, not a keyword)
+<ForLoopOptions> ::=
+   token::punctuation::AngleBracketOpen
+   <TokenSequenceOption>
+   (token::punctuation::Comma <TokenSequenceOption>)*
+   token::punctuation::AngleBracketClose
+
 <MessageForLoop> ::=
    token::keyword::For
+   <ForLoopOptions>?
    <IdentifierReference>
    token::keyword::In
    <IdentifierReference>
    token::punctuation::CurlyBraceOpen
    <MessagePart>*
    token::punctuation::CurlyBraceClose
+
 <MessagePart> ::=
    <TokenSequence> |
    <Terminator> |

--- a/src/networkprotocoldsl/codegen/generate_parser.cpp
+++ b/src/networkprotocoldsl/codegen/generate_parser.cpp
@@ -165,12 +165,15 @@ void generate_message_parser_parse(std::ostringstream &source,
             source << "            break;\n";
           } else if constexpr (std::is_same_v<
                                    T, sema::ast::action::ReadOctetsUntilTerminator>) {
-            // Read until terminator (with optional escape sequence support)
+            // Read until terminator (with optional escape replacement support)
             std::string escaped =
                 OutputContext::escape_string_literal(a->terminator);
             source << "            // Read until terminator: " << escaped;
             if (a->escape.has_value()) {
-              source << " (escape: " << OutputContext::escape_string_literal(a->escape.value()) << ")";
+              source << " (escape: replace " 
+                     << OutputContext::escape_string_literal(a->escape->character)
+                     << " with " 
+                     << OutputContext::escape_string_literal(a->escape->sequence) << ")";
             }
             source << "\n";
             source << "            {\n";
@@ -180,9 +183,12 @@ void generate_message_parser_parse(std::ostringstream &source,
                    << escaped << ";\n";
             
             if (a->escape.has_value()) {
-              std::string escape_escaped = OutputContext::escape_string_literal(a->escape.value());
-              source << "                constexpr size_t escape_len = " << a->escape.value().size() << ";\n";
-              source << "                static const char escape_seq[] = " << escape_escaped << ";\n";
+              std::string escape_seq_escaped = OutputContext::escape_string_literal(a->escape->sequence);
+              std::string escape_char_escaped = OutputContext::escape_string_literal(a->escape->character);
+              source << "                constexpr size_t escape_seq_len = " << a->escape->sequence.size() << ";\n";
+              source << "                static const char escape_seq[] = " << escape_seq_escaped << ";\n";
+              source << "                static const char escape_char[] = " << escape_char_escaped << ";\n";
+              source << "                constexpr size_t escape_char_len = " << a->escape->character.size() << ";\n";
             }
             
             source << "                \n";
@@ -191,17 +197,18 @@ void generate_message_parser_parse(std::ostringstream &source,
             source << "                bool found = false;\n";
             
             if (a->escape.has_value()) {
-              // With escape sequence support - more complex loop
+              // With escape replacement support - more complex loop
               source << "                while (pos + term_len <= input.size()) {\n";
               source << "                    // Check for escape sequence first\n";
-              source << "                    if (pos + escape_len <= input.size() &&\n";
-              source << "                        std::memcmp(input.data() + pos, escape_seq, escape_len) == 0) {\n";
-              source << "                        // Found escape - buffer data before escape, skip escape, continue\n";
+              source << "                    if (pos + escape_seq_len <= input.size() &&\n";
+              source << "                        std::memcmp(input.data() + pos, escape_seq, escape_seq_len) == 0) {\n";
+              source << "                        // Found escape - buffer data before it, add replacement char, skip escape\n";
               if (a->identifier) {
                 source << "                        " << a->identifier->name << "_buffer_.append(input.data(), pos);\n";
+                source << "                        " << a->identifier->name << "_buffer_.append(escape_char, escape_char_len);\n";
               }
-              source << "                        input.remove_prefix(pos + escape_len);\n";
-              source << "                        total_consumed += pos + escape_len;\n";
+              source << "                        input.remove_prefix(pos + escape_seq_len);\n";
+              source << "                        total_consumed += pos + escape_seq_len;\n";
               source << "                        pos = 0; // Reset position for new search\n";
               source << "                        continue;\n";
               source << "                    }\n";

--- a/src/networkprotocoldsl/codegen/generate_parser.cpp
+++ b/src/networkprotocoldsl/codegen/generate_parser.cpp
@@ -165,29 +165,65 @@ void generate_message_parser_parse(std::ostringstream &source,
             source << "            break;\n";
           } else if constexpr (std::is_same_v<
                                    T, sema::ast::action::ReadOctetsUntilTerminator>) {
-            // Read until terminator
+            // Read until terminator (with optional escape sequence support)
             std::string escaped =
                 OutputContext::escape_string_literal(a->terminator);
-            source << "            // Read until terminator: " << escaped
-                   << "\n";
+            source << "            // Read until terminator: " << escaped;
+            if (a->escape.has_value()) {
+              source << " (escape: " << OutputContext::escape_string_literal(a->escape.value()) << ")";
+            }
+            source << "\n";
             source << "            {\n";
             source << "                constexpr size_t term_len = "
                    << a->terminator.size() << ";\n";
             source << "                static const char terminator[] = "
                    << escaped << ";\n";
+            
+            if (a->escape.has_value()) {
+              std::string escape_escaped = OutputContext::escape_string_literal(a->escape.value());
+              source << "                constexpr size_t escape_len = " << a->escape.value().size() << ";\n";
+              source << "                static const char escape_seq[] = " << escape_escaped << ";\n";
+            }
+            
             source << "                \n";
             source << "                // Search for terminator in input\n";
             source << "                size_t pos = 0;\n";
             source << "                bool found = false;\n";
-            source << "                while (pos + term_len <= input.size()) "
-                      "{\n";
-            source << "                    if (std::memcmp(input.data() + pos, "
-                      "terminator, term_len) == 0) {\n";
-            source << "                        found = true;\n";
-            source << "                        break;\n";
-            source << "                    }\n";
-            source << "                    ++pos;\n";
-            source << "                }\n";
+            
+            if (a->escape.has_value()) {
+              // With escape sequence support - more complex loop
+              source << "                while (pos + term_len <= input.size()) {\n";
+              source << "                    // Check for escape sequence first\n";
+              source << "                    if (pos + escape_len <= input.size() &&\n";
+              source << "                        std::memcmp(input.data() + pos, escape_seq, escape_len) == 0) {\n";
+              source << "                        // Found escape - buffer data before escape, skip escape, continue\n";
+              if (a->identifier) {
+                source << "                        " << a->identifier->name << "_buffer_.append(input.data(), pos);\n";
+              }
+              source << "                        input.remove_prefix(pos + escape_len);\n";
+              source << "                        total_consumed += pos + escape_len;\n";
+              source << "                        pos = 0; // Reset position for new search\n";
+              source << "                        continue;\n";
+              source << "                    }\n";
+              source << "                    // Check for terminator\n";
+              source << "                    if (std::memcmp(input.data() + pos, terminator, term_len) == 0) {\n";
+              source << "                        found = true;\n";
+              source << "                        break;\n";
+              source << "                    }\n";
+              source << "                    ++pos;\n";
+              source << "                }\n";
+            } else {
+              // Original simple loop without escape handling
+              source << "                while (pos + term_len <= input.size()) {\n";
+              source << "                    if (std::memcmp(input.data() + pos, "
+                        "terminator, term_len) == 0) {\n";
+              source << "                        found = true;\n";
+              source << "                        break;\n";
+              source << "                    }\n";
+              source << "                    ++pos;\n";
+              source << "                }\n";
+            }
+            
             source << "                \n";
             source << "                if (found) {\n";
             if (a->identifier) {

--- a/src/networkprotocoldsl/lexer/tokenize.cpp
+++ b/src/networkprotocoldsl/lexer/tokenize.cpp
@@ -96,6 +96,7 @@ const std::vector<TokenRule> token_rules = {
     {";",
      [](TP_ARGS) { tokens.push_back(token::punctuation::StatementEnd()); }},
     {"\\.", [](TP_ARGS) { tokens.push_back(token::punctuation::Dot()); }},
+    {"\\/\\/[^\\n]*", [](TP_ARGS) {}}, // Single-line comments (// ...)
     {"[ \\t\\n]+", [](TP_ARGS) {}}, // No action for whitespace
     {"[a-zA-Z][a-zA-Z0-9_]*",
      [](TP_ARGS) { tokens.push_back(token::Identifier{std::string(str)}); }}};

--- a/src/networkprotocoldsl/operation.hpp
+++ b/src/networkprotocoldsl/operation.hpp
@@ -33,6 +33,7 @@
 #include <networkprotocoldsl/operation/unarycallback.hpp>
 #include <networkprotocoldsl/operation/writeint32native.hpp>
 #include <networkprotocoldsl/operation/writeoctets.hpp>
+#include <networkprotocoldsl/operation/writeoctetswithescape.hpp>
 #include <networkprotocoldsl/operation/writestaticoctets.hpp>
 
 #include <variant>
@@ -58,10 +59,10 @@ using Operation = std::variant<
     operation::StaticCallable, operation::Subtract,
     operation::TerminateListIfReadAhead, operation::UnaryCallback,
     operation::WriteInt32Native, operation::WriteOctets,
-    operation::WriteStaticOctets, operation::DictionaryInitialize,
-    operation::DictionarySet, operation::DictionaryGet,
-    operation::LexicalPadAsDict, operation::TransitionLookahead,
-    operation::StateMachineOperation>;
+    operation::WriteOctetsWithEscape, operation::WriteStaticOctets,
+    operation::DictionaryInitialize, operation::DictionarySet,
+    operation::DictionaryGet, operation::LexicalPadAsDict,
+    operation::TransitionLookahead, operation::StateMachineOperation>;
 
 } // namespace networkprotocoldsl
 

--- a/src/networkprotocoldsl/operation/readoctetsuntilterminator.cpp
+++ b/src/networkprotocoldsl/operation/readoctetsuntilterminator.cpp
@@ -21,6 +21,54 @@ ReadOctetsUntilTerminator::operator()(InputOutputOperationContext &ctx,
 
 size_t ReadOctetsUntilTerminator::handle_read(InputOutputOperationContext &ctx,
                                               std::string_view in) const {
+  // If we have escape sequences to handle, we need to search for both
+  // the terminator and the escape sequence
+  if (escape_char.has_value() && escape_sequence.has_value()) {
+    size_t pos = 0;
+    while (pos < in.size()) {
+      // Find the earliest occurrence of terminator or escape_sequence
+      auto term_pos = in.find(terminator, pos);
+      auto esc_pos = in.find(*escape_sequence, pos);
+      
+      if (term_pos == in.npos && esc_pos == in.npos) {
+        // Neither found yet - need more data
+        return 0;
+      }
+      
+      // When escape_sequence starts with terminator (e.g., "\r\n " vs "\r\n"),
+      // we need to prefer the escape sequence when it fully matches
+      bool prefer_escape = false;
+      if (esc_pos != in.npos) {
+        if (term_pos == in.npos) {
+          prefer_escape = true;
+        } else if (esc_pos < term_pos) {
+          prefer_escape = true;
+        } else if (esc_pos == term_pos) {
+          // Same position - escape sequence is longer and contains terminator,
+          // so if escape matches, prefer it
+          prefer_escape = true;
+        }
+      }
+      
+      if (prefer_escape) {
+        // Escape sequence found before terminator
+        // Append data up to escape sequence, then the escape character
+        ctx.buffer.append(in.begin() + pos, in.begin() + esc_pos);
+        ctx.buffer.append(*escape_char);
+        pos = esc_pos + escape_sequence->size();
+        continue;
+      }
+      
+      // Terminator found (and it's before any escape sequence)
+      ctx.buffer.append(in.begin() + pos, in.begin() + term_pos);
+      ctx.ready = true;
+      return term_pos + terminator.size();
+    }
+    // We processed the whole input but didn't find terminator
+    return 0;
+  }
+  
+  // No escape handling - simple case
   auto pos = in.find(terminator);
   if (pos == in.npos) {
     return 0;

--- a/src/networkprotocoldsl/operation/readoctetsuntilterminator.hpp
+++ b/src/networkprotocoldsl/operation/readoctetsuntilterminator.hpp
@@ -17,10 +17,19 @@ namespace operation {
 
 class ReadOctetsUntilTerminator {
   const std::string terminator;
+  // Optional escape replacement: when escape_sequence is found in input,
+  // it is replaced with escape_char in the captured value
+  const std::optional<std::string> escape_char;
+  const std::optional<std::string> escape_sequence;
 
 public:
   using Arguments = std::tuple<>;
   ReadOctetsUntilTerminator(const std::string &_t) : terminator(_t) {}
+  ReadOctetsUntilTerminator(const std::string &_t,
+                            const std::string &_escape_char,
+                            const std::string &_escape_sequence)
+      : terminator(_t), escape_char(_escape_char),
+        escape_sequence(_escape_sequence) {}
 
   OperationResult operator()(InputOutputOperationContext &ctx,
                              Arguments a) const;
@@ -36,7 +45,12 @@ public:
   bool ready_to_evaluate(InputOutputOperationContext &ctx) const;
 
   std::string stringify() const {
-    return "ReadOctetsUntilTerminator{terminator: \"" + terminator + "\"}";
+    std::string result = "ReadOctetsUntilTerminator{terminator: \"" + terminator + "\"";
+    if (escape_char.has_value() && escape_sequence.has_value()) {
+      result += ", escape_char: \"" + *escape_char + "\", escape_sequence: \"" + *escape_sequence + "\"";
+    }
+    result += "}";
+    return result;
   }
 };
 static_assert(InputOutputOperationConcept<ReadOctetsUntilTerminator>);

--- a/src/networkprotocoldsl/operation/writeoctetswithescape.cpp
+++ b/src/networkprotocoldsl/operation/writeoctetswithescape.cpp
@@ -1,0 +1,111 @@
+#include <networkprotocoldsl/operation/writeoctetswithescape.hpp>
+#include <networkprotocoldsl/operationconcepts.hpp>
+#include <networkprotocoldsl/value.hpp>
+
+#include <cstring>
+
+namespace networkprotocoldsl::operation {
+
+// Helper to perform escape replacement on a string
+static std::string apply_escape_replacement(const std::string &input,
+                                            const std::string &escape_char,
+                                            const std::string &escape_sequence) {
+  std::string result;
+  result.reserve(input.size()); // Reserve at least input size
+  
+  size_t pos = 0;
+  while (pos < input.size()) {
+    auto esc_pos = input.find(escape_char, pos);
+    if (esc_pos == std::string::npos) {
+      // No more escape chars, append rest of string
+      result.append(input, pos, input.size() - pos);
+      break;
+    }
+    // Append up to the escape char
+    result.append(input, pos, esc_pos - pos);
+    // Append the escape sequence instead of escape char
+    result.append(escape_sequence);
+    pos = esc_pos + escape_char.size();
+  }
+  
+  return result;
+}
+
+static OperationResult _execute_operation(InputOutputOperationContext &ctx,
+                                          value::Octets &oct,
+                                          const std::string &escape_char,
+                                          const std::string &escape_sequence) {
+  if (oct.data->length() == 0) {
+    return 0;
+  } else if (ctx.buffer.length() == 0) {
+    // Apply escape replacement when first initializing the buffer
+    ctx.buffer = apply_escape_replacement(*(oct.data), escape_char, escape_sequence);
+    ctx.it = ctx.buffer.begin();
+  }
+  if (ctx.it != ctx.buffer.end()) {
+    if (ctx.eof) {
+      return value::RuntimeError::ProtocolMismatchError;
+    } else {
+      return ReasonForBlockedOperation::WaitingForWrite;
+    }
+  } else {
+    return 0;
+  }
+}
+
+static OperationResult _execute_operation(InputOutputOperationContext &ctx,
+                                          value::RuntimeError v,
+                                          const std::string &,
+                                          const std::string &) {
+  return v;
+}
+
+static OperationResult _execute_operation(InputOutputOperationContext &ctx,
+                                          value::ControlFlowInstruction v,
+                                          const std::string &,
+                                          const std::string &) {
+  return v;
+}
+
+static OperationResult _execute_operation(InputOutputOperationContext &ctx,
+                                          auto unknown,
+                                          const std::string &,
+                                          const std::string &) {
+  return value::RuntimeError::TypeError;
+}
+
+OperationResult WriteOctetsWithEscape::operator()(InputOutputOperationContext &ctx,
+                                                  Arguments a) const {
+  return std::visit(
+      [&ctx, this](auto arg) {
+        return _execute_operation(ctx, arg, escape_char, escape_sequence);
+      },
+      std::get<0>(a));
+}
+
+void WriteOctetsWithEscape::handle_eof(InputOutputOperationContext &ctx) const {
+  ctx.eof = true;
+}
+
+size_t WriteOctetsWithEscape::handle_read(InputOutputOperationContext &ctx,
+                                          std::string_view in) const {
+  return 0;
+}
+
+std::string_view
+WriteOctetsWithEscape::get_write_buffer(InputOutputOperationContext &ctx) const {
+  return std::string_view(ctx.it, ctx.buffer.end());
+}
+
+size_t WriteOctetsWithEscape::handle_write(InputOutputOperationContext &ctx,
+                                           size_t s) const {
+  size_t consumed = 0;
+  while (s > 0 && ctx.it != ctx.buffer.end()) {
+    s--;
+    consumed++;
+    ctx.it++;
+  }
+  return consumed;
+}
+
+} // namespace networkprotocoldsl::operation

--- a/src/networkprotocoldsl/operation/writeoctetswithescape.cpp
+++ b/src/networkprotocoldsl/operation/writeoctetswithescape.cpp
@@ -6,12 +6,14 @@
 
 namespace networkprotocoldsl::operation {
 
-// Helper to perform escape replacement on a string
+// Helper to perform escape replacement on a string.
+// Replaces occurrences of escape_char with escape_sequence in the output.
 static std::string apply_escape_replacement(const std::string &input,
                                             const std::string &escape_char,
                                             const std::string &escape_sequence) {
   std::string result;
-  result.reserve(input.size()); // Reserve at least input size
+  // Reserve extra space since escape_sequence is typically longer than escape_char
+  result.reserve(input.size() + input.size() / 4);
   
   size_t pos = 0;
   while (pos < input.size()) {

--- a/src/networkprotocoldsl/operation/writeoctetswithescape.hpp
+++ b/src/networkprotocoldsl/operation/writeoctetswithescape.hpp
@@ -1,0 +1,56 @@
+#ifndef INCLUDED_NETWORKPROTOCOLDSL_OPERATION_WRITEOCTETSWITHESCAPE_H
+#define INCLUDED_NETWORKPROTOCOLDSL_OPERATION_WRITEOCTETSWITHESCAPE_H
+
+#include <networkprotocoldsl/operationconcepts.hpp>
+#include <networkprotocoldsl/value.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <variant>
+
+namespace networkprotocoldsl {
+
+namespace operation {
+
+// WriteOctetsWithEscape writes octets, replacing escape_char with escape_sequence
+// For example, if escape_char="\n" and escape_sequence="\r\n ",
+// writing "hello\nworld" produces "hello\r\n world"
+class WriteOctetsWithEscape {
+  const std::string escape_char;
+  const std::string escape_sequence;
+
+public:
+  using Arguments = std::tuple<Value>;
+  WriteOctetsWithEscape(const std::string &_escape_char,
+                        const std::string &_escape_sequence)
+      : escape_char(_escape_char), escape_sequence(_escape_sequence) {}
+
+  OperationResult operator()(InputOutputOperationContext &ctx,
+                             Arguments a) const;
+  size_t handle_read(InputOutputOperationContext &ctx,
+                     std::string_view in) const;
+
+  std::string_view get_write_buffer(InputOutputOperationContext &ctx) const;
+  void handle_eof(InputOutputOperationContext &ctx) const;
+
+  size_t handle_write(InputOutputOperationContext &ctx, size_t s) const;
+
+  bool ready_to_evaluate(InputOutputOperationContext &ctx) const {
+    return true; // Write operations don't wait for input
+  }
+
+  std::string stringify() const {
+    return "WriteOctetsWithEscape{escape_char: \"" + escape_char +
+           "\", escape_sequence: \"" + escape_sequence + "\"}";
+  }
+};
+static_assert(InputOutputOperationConcept<WriteOctetsWithEscape>);
+
+} // namespace operation
+
+} // namespace networkprotocoldsl
+
+#endif

--- a/src/networkprotocoldsl/parser/grammar/messagesequence.hpp
+++ b/src/networkprotocoldsl/parser/grammar/messagesequence.hpp
@@ -1,7 +1,10 @@
 #ifndef INCLUDED_NETWORKPROTOCOLDSL_PARSER_GRAMMAR_MESSAGEFORLOOP_HPP
 #define INCLUDED_NETWORKPROTOCOLDSL_PARSER_GRAMMAR_MESSAGEFORLOOP_HPP
 
+#include <map>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include <networkprotocoldsl/lexer/token.hpp>
@@ -21,30 +24,36 @@ class MessageForLoop
 public:
   static constexpr const char *name = "MessageForLoop";
   static void partial_match() {}
-  static IdentifierReference *recurse_one(lexer::token::keyword::For) {
+  // Try to parse optional options first
+  static TokenSequenceOptions *recurse_maybe(lexer::token::keyword::For) {
     return nullptr;
   }
-  static void partial_match(lexer::token::keyword::For,
+  // When no options provided (nullopt case) - go directly to recurse_one
+  static IdentifierReference *recurse_one(lexer::token::keyword::For,
+                                          std::nullopt_t) {
+    return nullptr;
+  }
+  static void partial_match(lexer::token::keyword::For, std::nullopt_t,
                             std::shared_ptr<const tree::IdentifierReference>) {}
   static IdentifierReference *
-  recurse_one(lexer::token::keyword::For,
+  recurse_one(lexer::token::keyword::For, std::nullopt_t,
               std::shared_ptr<const tree::IdentifierReference>,
               lexer::token::keyword::In) {
     return nullptr;
   }
-  static void partial_match(lexer::token::keyword::For,
+  static void partial_match(lexer::token::keyword::For, std::nullopt_t,
                             std::shared_ptr<const tree::IdentifierReference>,
                             lexer::token::keyword::In,
                             std::shared_ptr<const tree::IdentifierReference>) {}
   static MessageSequence *
-  recurse_one(lexer::token::keyword::For,
+  recurse_one(lexer::token::keyword::For, std::nullopt_t,
               std::shared_ptr<const tree::IdentifierReference>,
               lexer::token::keyword::In,
               std::shared_ptr<const tree::IdentifierReference>,
               lexer::token::punctuation::CurlyBraceOpen) {
     return nullptr;
   }
-  static void partial_match(lexer::token::keyword::For,
+  static void partial_match(lexer::token::keyword::For, std::nullopt_t,
                             std::shared_ptr<const tree::IdentifierReference>,
                             lexer::token::keyword::In,
                             std::shared_ptr<const tree::IdentifierReference>,
@@ -52,14 +61,72 @@ public:
                             std::shared_ptr<const tree::MessageSequence>) {}
   static ParseStateReturn
   match(TokenIterator begin, TokenIterator end, lexer::token::keyword::For,
+        std::nullopt_t,
         std::shared_ptr<const tree::IdentifierReference> identifier1,
         lexer::token::keyword::In,
         std::shared_ptr<const tree::IdentifierReference> identifier2,
         lexer::token::punctuation::CurlyBraceOpen,
         std::shared_ptr<const tree::MessageSequence> seq,
         lexer::token::punctuation::CurlyBraceClose) {
-    return {std::make_shared<const tree::MessageForLoop>(identifier1,
-                                                         identifier2, seq),
+    return {std::make_shared<const tree::MessageForLoop>(tree::MessageForLoop{
+                identifier1, identifier2, seq, std::nullopt}),
+            begin, end};
+  }
+  // When options are provided - go directly to recurse_one
+  static IdentifierReference *
+  recurse_one(lexer::token::keyword::For,
+              std::shared_ptr<tree::TokenSequenceOptionsMap>) {
+    return nullptr;
+  }
+  static void partial_match(lexer::token::keyword::For,
+                            std::shared_ptr<tree::TokenSequenceOptionsMap>,
+                            std::shared_ptr<const tree::IdentifierReference>) {}
+  static IdentifierReference *
+  recurse_one(lexer::token::keyword::For,
+              std::shared_ptr<tree::TokenSequenceOptionsMap>,
+              std::shared_ptr<const tree::IdentifierReference>,
+              lexer::token::keyword::In) {
+    return nullptr;
+  }
+  static void partial_match(lexer::token::keyword::For,
+                            std::shared_ptr<tree::TokenSequenceOptionsMap>,
+                            std::shared_ptr<const tree::IdentifierReference>,
+                            lexer::token::keyword::In,
+                            std::shared_ptr<const tree::IdentifierReference>) {}
+  static MessageSequence *
+  recurse_one(lexer::token::keyword::For,
+              std::shared_ptr<tree::TokenSequenceOptionsMap>,
+              std::shared_ptr<const tree::IdentifierReference>,
+              lexer::token::keyword::In,
+              std::shared_ptr<const tree::IdentifierReference>,
+              lexer::token::punctuation::CurlyBraceOpen) {
+    return nullptr;
+  }
+  static void partial_match(lexer::token::keyword::For,
+                            std::shared_ptr<tree::TokenSequenceOptionsMap>,
+                            std::shared_ptr<const tree::IdentifierReference>,
+                            lexer::token::keyword::In,
+                            std::shared_ptr<const tree::IdentifierReference>,
+                            lexer::token::punctuation::CurlyBraceOpen,
+                            std::shared_ptr<const tree::MessageSequence>) {}
+  static ParseStateReturn
+  match(TokenIterator begin, TokenIterator end, lexer::token::keyword::For,
+        std::shared_ptr<tree::TokenSequenceOptionsMap> options,
+        std::shared_ptr<const tree::IdentifierReference> identifier1,
+        lexer::token::keyword::In,
+        std::shared_ptr<const tree::IdentifierReference> identifier2,
+        lexer::token::punctuation::CurlyBraceOpen,
+        std::shared_ptr<const tree::MessageSequence> seq,
+        lexer::token::punctuation::CurlyBraceClose) {
+    std::optional<std::string> terminator;
+    if (options) {
+      auto &opts = *options;
+      if (opts.count("terminator")) {
+        terminator = opts.at("terminator");
+      }
+    }
+    return {std::make_shared<const tree::MessageForLoop>(
+                tree::MessageForLoop{identifier1, identifier2, seq, terminator}),
             begin, end};
   }
 };

--- a/src/networkprotocoldsl/parser/grammar/messagesequence.hpp
+++ b/src/networkprotocoldsl/parser/grammar/messagesequence.hpp
@@ -122,7 +122,10 @@ public:
     if (options) {
       auto &opts = *options;
       if (opts.count("terminator")) {
-        terminator = opts.at("terminator");
+        auto &val = opts.at("terminator");
+        if (std::holds_alternative<std::string>(val)) {
+          terminator = std::get<std::string>(val);
+        }
       }
     }
     return {std::make_shared<const tree::MessageForLoop>(

--- a/src/networkprotocoldsl/parser/grammar/traits.hpp
+++ b/src/networkprotocoldsl/parser/grammar/traits.hpp
@@ -40,6 +40,8 @@ using NodeVariant =
                  std::shared_ptr<const tree::TypeParameterMap>,
                  std::shared_ptr<const tree::TokenSequence>,
                  std::shared_ptr<const tree::TokenPart>,
+                 std::shared_ptr<tree::EscapeReplacement>,
+                 std::shared_ptr<tree::TokenSequenceOptionValue>,
                  std::shared_ptr<const tree::TokenSequenceOptionPair>,
                  std::shared_ptr<const tree::TokenSequenceOptionsMap>,
                  std::shared_ptr<const tree::Terminator>,

--- a/src/networkprotocoldsl/parser/grammar/traits.hpp
+++ b/src/networkprotocoldsl/parser/grammar/traits.hpp
@@ -21,6 +21,7 @@
 #include <networkprotocoldsl/parser/tree/terminator.hpp>
 #include <networkprotocoldsl/parser/tree/tokenpart.hpp>
 #include <networkprotocoldsl/parser/tree/tokensequence.hpp>
+#include <networkprotocoldsl/parser/tree/tokensequenceoptions.hpp>
 #include <networkprotocoldsl/parser/tree/type.hpp>
 #include <networkprotocoldsl/parser/tree/typeparametermap.hpp>
 #include <networkprotocoldsl/parser/tree/typeparametervalue.hpp>
@@ -39,6 +40,8 @@ using NodeVariant =
                  std::shared_ptr<const tree::TypeParameterMap>,
                  std::shared_ptr<const tree::TokenSequence>,
                  std::shared_ptr<const tree::TokenPart>,
+                 std::shared_ptr<const tree::TokenSequenceOptionPair>,
+                 std::shared_ptr<const tree::TokenSequenceOptionsMap>,
                  std::shared_ptr<const tree::Terminator>,
                  std::shared_ptr<const tree::ProtocolDescription>,
                  std::shared_ptr<const tree::MessageSequence>,

--- a/src/networkprotocoldsl/parser/tree/messageforloop.hpp
+++ b/src/networkprotocoldsl/parser/tree/messageforloop.hpp
@@ -4,6 +4,8 @@
 #include <memory>
 #include <networkprotocoldsl/parser/tree/identifierreference.hpp>
 #include <networkprotocoldsl/parser/tree/messagesequence.hpp>
+#include <optional>
+#include <string>
 
 namespace networkprotocoldsl::parser::tree {
 
@@ -12,9 +14,15 @@ struct MessageForLoop {
   std::shared_ptr<const IdentifierReference> variable;
   std::shared_ptr<const IdentifierReference> collection;
   std::shared_ptr<const MessageSequence> block;
-  std::string stringigy() const {
-    return "for " + variable->stringify() + " in " + collection->stringify() +
-           " {...}";
+  std::optional<std::string> terminator;
+  std::string stringify() const {
+    std::string result = "for";
+    if (terminator.has_value()) {
+      result += " <terminator=\"" + terminator.value() + "\">";
+    }
+    result += " " + variable->stringify() + " in " + collection->stringify() +
+              " {...}";
+    return result;
   }
 };
 

--- a/src/networkprotocoldsl/parser/tree/tokensequence.hpp
+++ b/src/networkprotocoldsl/parser/tree/tokensequence.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <networkprotocoldsl/parser/tree/tokenpart.hpp>
+#include <networkprotocoldsl/parser/tree/tokensequenceoptions.hpp>
 #include <optional>
 #include <string>
 #include <vector>
@@ -12,7 +13,7 @@ namespace networkprotocoldsl::parser::tree {
 struct TokenSequence {
   std::vector<std::shared_ptr<const TokenPart>> tokens;
   std::optional<std::string> terminator;
-  std::optional<std::string> escape;
+  std::optional<EscapeReplacement> escape;
   std::string stringify() const {
     std::string result = "tokens";
     if (terminator.has_value() || escape.has_value()) {
@@ -24,7 +25,7 @@ struct TokenSequence {
         }
       }
       if (escape.has_value()) {
-        result += "escape=\"" + escape.value() + "\"";
+        result += "escape=replace<\"" + escape.value().character + "\", \"" + escape.value().sequence + "\">";
       }
       result += ">";
     }

--- a/src/networkprotocoldsl/parser/tree/tokensequence.hpp
+++ b/src/networkprotocoldsl/parser/tree/tokensequence.hpp
@@ -3,14 +3,32 @@
 
 #include <memory>
 #include <networkprotocoldsl/parser/tree/tokenpart.hpp>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace networkprotocoldsl::parser::tree {
 
 struct TokenSequence {
   std::vector<std::shared_ptr<const TokenPart>> tokens;
+  std::optional<std::string> terminator;
+  std::optional<std::string> escape;
   std::string stringify() const {
-    std::string result = "tokens {";
+    std::string result = "tokens";
+    if (terminator.has_value() || escape.has_value()) {
+      result += " <";
+      if (terminator.has_value()) {
+        result += "terminator=\"" + terminator.value() + "\"";
+        if (escape.has_value()) {
+          result += ", ";
+        }
+      }
+      if (escape.has_value()) {
+        result += "escape=\"" + escape.value() + "\"";
+      }
+      result += ">";
+    }
+    result += " {";
     for (const auto &part : tokens) {
       result += std::visit([](auto &&arg) { return arg->stringify(); }, *part);
     }

--- a/src/networkprotocoldsl/parser/tree/tokensequenceoptions.hpp
+++ b/src/networkprotocoldsl/parser/tree/tokensequenceoptions.hpp
@@ -2,16 +2,29 @@
 #define INCLUDED_NETWORKPROTOCOLDSL_PARSER_TREE_TOKENSEQUENCEOPTIONS_HPP
 
 #include <map>
+#include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 
 namespace networkprotocoldsl::parser::tree {
 
-// A key-value pair for token sequence options (e.g., terminator="\r\n")
-using TokenSequenceOptionPair = std::pair<std::string, std::string>;
+// Escape replacement: replace<"char", "sequence">
+// - character: the character to represent in the captured value (e.g., "\n")
+// - sequence: the escape sequence on the wire (e.g., "\r\n ")
+struct EscapeReplacement {
+  std::string character;  // what appears in the captured/serialized value
+  std::string sequence;   // what appears on the wire
+};
 
-// A map of option names to their string values
-using TokenSequenceOptionsMap = std::map<std::string, std::string>;
+// A token sequence option value can be a simple string or an escape replacement
+using TokenSequenceOptionValue = std::variant<std::string, EscapeReplacement>;
+
+// A key-value pair for token sequence options (e.g., terminator="\r\n")
+using TokenSequenceOptionPair = std::pair<std::string, TokenSequenceOptionValue>;
+
+// A map of option names to their values
+using TokenSequenceOptionsMap = std::map<std::string, TokenSequenceOptionValue>;
 
 } // namespace networkprotocoldsl::parser::tree
 

--- a/src/networkprotocoldsl/parser/tree/tokensequenceoptions.hpp
+++ b/src/networkprotocoldsl/parser/tree/tokensequenceoptions.hpp
@@ -1,0 +1,18 @@
+#ifndef INCLUDED_NETWORKPROTOCOLDSL_PARSER_TREE_TOKENSEQUENCEOPTIONS_HPP
+#define INCLUDED_NETWORKPROTOCOLDSL_PARSER_TREE_TOKENSEQUENCEOPTIONS_HPP
+
+#include <map>
+#include <string>
+#include <utility>
+
+namespace networkprotocoldsl::parser::tree {
+
+// A key-value pair for token sequence options (e.g., terminator="\r\n")
+using TokenSequenceOptionPair = std::pair<std::string, std::string>;
+
+// A map of option names to their string values
+using TokenSequenceOptionsMap = std::map<std::string, std::string>;
+
+} // namespace networkprotocoldsl::parser::tree
+
+#endif // INCLUDED_NETWORKPROTOCOLDSL_PARSER_TREE_TOKENSEQUENCEOPTIONS_HPP

--- a/src/networkprotocoldsl/sema/ast/action/read.hpp
+++ b/src/networkprotocoldsl/sema/ast/action/read.hpp
@@ -2,6 +2,7 @@
 #define INCLUDED_NETWORKPROTOCOLDSL_SEMA_AST_ACTION_READ_HPP
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -16,6 +17,9 @@ struct ReadStaticOctets {
 struct ReadOctetsUntilTerminator {
   std::string terminator;
   std::shared_ptr<const parser::tree::IdentifierReference> identifier;
+  // Optional escape sequence - if present and found before terminator,
+  // the escape is removed and reading continues (for HTTP header continuation)
+  std::optional<std::string> escape;
 };
 
 } // namespace networkprotocoldsl::sema::ast::action

--- a/src/networkprotocoldsl/sema/ast/action/read.hpp
+++ b/src/networkprotocoldsl/sema/ast/action/read.hpp
@@ -14,12 +14,19 @@ struct ReadStaticOctets {
   std::string octets;
 };
 
+// Escape replacement info for ReadOctetsUntilTerminator
+struct EscapeInfo {
+  std::string character;  // what to insert in the captured value (e.g., "\n")
+  std::string sequence;   // what appears on the wire (e.g., "\r\n ")
+};
+
 struct ReadOctetsUntilTerminator {
   std::string terminator;
   std::shared_ptr<const parser::tree::IdentifierReference> identifier;
-  // Optional escape sequence - if present and found before terminator,
-  // the escape is removed and reading continues (for HTTP header continuation)
-  std::optional<std::string> escape;
+  // Optional escape replacement - if present:
+  // - when parsing: replace escape_sequence with escape_char in captured value
+  // - when serializing: replace escape_char with escape_sequence in output
+  std::optional<EscapeInfo> escape;
 };
 
 } // namespace networkprotocoldsl::sema::ast::action

--- a/src/networkprotocoldsl/sema/ast/action/write.hpp
+++ b/src/networkprotocoldsl/sema/ast/action/write.hpp
@@ -2,14 +2,19 @@
 #define INCLUDED_NETWORKPROTOCOLDSL_SEMA_AST_ACTION_WRITE_HPP
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <networkprotocoldsl/parser/tree/identifierreference.hpp>
+#include <networkprotocoldsl/sema/ast/action/read.hpp>
 
 namespace networkprotocoldsl::sema::ast::action {
 
 struct WriteFromIdentifier {
   std::shared_ptr<const parser::tree::IdentifierReference> identifier;
+  // Optional escape replacement - if present:
+  // when serializing: replace escape_char with escape_sequence in output
+  std::optional<EscapeInfo> escape;
 };
 
 struct WriteStaticOctets {

--- a/src/networkprotocoldsl/sema/partstoreadactions.cpp
+++ b/src/networkprotocoldsl/sema/partstoreadactions.cpp
@@ -142,7 +142,9 @@ public:
         std::shared_ptr<const parser::tree::Terminator> terminator) {
     // We have an external Terminator block - check that token_sequence doesn't have embedded terminator
     if (token_sequence->terminator.has_value()) {
-      // Error: both embedded terminator option AND explicit Terminator block
+      // Error: conflicting terminator definitions - both embedded terminator option
+      // in tokens<terminator="..."> AND explicit terminator { } block.
+      // Use one or the other, not both.
       return {std::nullopt, begin, end};
     }
     // Use the external Terminator block's value

--- a/src/networkprotocoldsl/sema/partstoreadactions.cpp
+++ b/src/networkprotocoldsl/sema/partstoreadactions.cpp
@@ -95,6 +95,26 @@ public:
   static void partial_match(){};
   static void
       partial_match(std::shared_ptr<const parser::tree::TokenSequence>){};
+
+  // Helper to apply escape sequence to ReadOctetsUntilTerminator actions
+  static void apply_escape_to_actions(std::vector<ast::Action> &actions,
+                                       const std::optional<std::string> &escape) {
+    if (!escape.has_value()) return;
+    for (auto &action : actions) {
+      std::visit([&](auto &a) {
+        using T = std::decay_t<decltype(*a)>;
+        if constexpr (std::is_same_v<T, ast::action::ReadOctetsUntilTerminator>) {
+          // Create a new action with the escape sequence
+          auto new_action = std::make_shared<ast::action::ReadOctetsUntilTerminator>();
+          new_action->terminator = a->terminator;
+          new_action->identifier = a->identifier;
+          new_action->escape = escape;
+          a = new_action;
+        }
+      }, action);
+    }
+  }
+
   static ParseStateReturn
   match(TokenIterator begin, TokenIterator end,
         std::shared_ptr<const parser::tree::TokenSequence> token_sequence,
@@ -103,6 +123,13 @@ public:
     auto full_sequence = unroll_variant(token_sequence->tokens);
     full_sequence.push_back(terminator->value);
     auto r = TokenSequence::parse(full_sequence.cbegin(), full_sequence.cend());
+    
+    // Apply escape sequence if present
+    if (r.node.has_value() && token_sequence->escape.has_value()) {
+      auto actions = std::get<std::vector<ast::Action>>(r.node.value());
+      apply_escape_to_actions(actions, token_sequence->escape);
+      return {actions, begin, end};
+    }
     return {r.node, begin, end};
   }
   static ParseStateReturn
@@ -112,6 +139,13 @@ public:
     // Parse the token sequence
     auto full_sequence = unroll_variant(token_sequence->tokens);
     auto r = TokenSequence::parse(full_sequence.cbegin(), full_sequence.cend());
+    
+    // Apply escape sequence if present
+    if (r.node.has_value() && token_sequence->escape.has_value()) {
+      auto actions = std::get<std::vector<ast::Action>>(r.node.value());
+      apply_escape_to_actions(actions, token_sequence->escape);
+      return {actions, begin, end};
+    }
     return {r.node, begin, end};
   }
   static void

--- a/tests/015-test-tokenizer.cpp
+++ b/tests/015-test-tokenizer.cpp
@@ -37,3 +37,112 @@ TEST(tokenizer, match) {
       std::holds_alternative<lexer::token::punctuation::CurlyBraceClose>(
           output->at(7)));
 }
+
+TEST(tokenizer, escape_replace_syntax) {
+  using namespace networkprotocoldsl;
+  // Test tokenizing the escape=replace<"\n", "\r\n "> syntax
+  std::string input(R"(tokens<terminator="\r\n", escape=replace<"\n", "\r\n ">> { host })");
+  auto output = lexer::tokenize(input);
+  ASSERT_TRUE(output.has_value()) << "Tokenization should succeed";
+  
+  // Expected tokens:
+  // 0: tokens (keyword)
+  // 1: <
+  // 2: terminator (keyword - reused for options)
+  // 3: =
+  // 4: "\r\n"
+  // 5: ,
+  // 6: escape (identifier)
+  // 7: =
+  // 8: replace (identifier)
+  // 9: <
+  // 10: "\n"
+  // 11: ,
+  // 12: "\r\n "
+  // 13: >
+  // 14: >
+  // 15: {
+  // 16: host (identifier)
+  // 17: }
+  
+  ASSERT_EQ(18, output->size()) << "Should have exactly 18 tokens";
+  
+  // tokens
+  ASSERT_TRUE(std::holds_alternative<lexer::token::keyword::Tokens>(output->at(0)))
+      << "Token 0 should be 'tokens' keyword";
+  
+  // <
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::AngleBracketOpen>(output->at(1)))
+      << "Token 1 should be '<'";
+  
+  // terminator (the keyword is reused for options)
+  ASSERT_TRUE(std::holds_alternative<lexer::token::keyword::Terminator>(output->at(2)))
+      << "Token 2 should be 'terminator' keyword";
+  
+  // =
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::Equal>(output->at(3)))
+      << "Token 3 should be '='";
+  
+  // "\r\n"
+  ASSERT_TRUE(std::holds_alternative<lexer::token::literal::String>(output->at(4)))
+      << "Token 4 should be string literal";
+  ASSERT_EQ("\r\n", std::get<lexer::token::literal::String>(output->at(4)).value);
+  
+  // ,
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::Comma>(output->at(5)))
+      << "Token 5 should be ','";
+  
+  // escape
+  ASSERT_TRUE(std::holds_alternative<lexer::token::Identifier>(output->at(6)))
+      << "Token 6 should be 'escape' identifier";
+  ASSERT_EQ("escape", std::get<lexer::token::Identifier>(output->at(6)).name);
+  
+  // =
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::Equal>(output->at(7)))
+      << "Token 7 should be '='";
+  
+  // replace
+  ASSERT_TRUE(std::holds_alternative<lexer::token::Identifier>(output->at(8)))
+      << "Token 8 should be 'replace' identifier";
+  ASSERT_EQ("replace", std::get<lexer::token::Identifier>(output->at(8)).name);
+  
+  // <
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::AngleBracketOpen>(output->at(9)))
+      << "Token 9 should be '<'";
+  
+  // "\n"
+  ASSERT_TRUE(std::holds_alternative<lexer::token::literal::String>(output->at(10)))
+      << "Token 10 should be string literal for escape char";
+  ASSERT_EQ("\n", std::get<lexer::token::literal::String>(output->at(10)).value);
+  
+  // ,
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::Comma>(output->at(11)))
+      << "Token 11 should be ','";
+  
+  // "\r\n "
+  ASSERT_TRUE(std::holds_alternative<lexer::token::literal::String>(output->at(12)))
+      << "Token 12 should be string literal for escape sequence";
+  ASSERT_EQ("\r\n ", std::get<lexer::token::literal::String>(output->at(12)).value);
+  
+  // > (closing replace<...>)
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::AngleBracketClose>(output->at(13)))
+      << "Token 13 should be '>'";
+  
+  // > (closing tokens<...>)
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::AngleBracketClose>(output->at(14)))
+      << "Token 14 should be '>'";
+  
+  // {
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::CurlyBraceOpen>(output->at(15)))
+      << "Token 15 should be '{'";
+  
+  // host
+  ASSERT_TRUE(std::holds_alternative<lexer::token::Identifier>(output->at(16)))
+      << "Token 16 should be 'host' identifier";
+  ASSERT_EQ("host", std::get<lexer::token::Identifier>(output->at(16)).name);
+  
+  // }
+  ASSERT_TRUE(std::holds_alternative<lexer::token::punctuation::CurlyBraceClose>(output->at(17)))
+      << "Token 17 should be '}'";
+}
+

--- a/tests/020-grammar-tokenpart.cpp
+++ b/tests/020-grammar-tokenpart.cpp
@@ -71,3 +71,80 @@ TEST(TokenPartTest, Terminator) {
       result.node.value());
   ASSERT_EQ(seq->value->value, ";");
 }
+
+TEST(TokenPartTest, EscapeReplacement) {
+  // Test parsing escape=replace<"\n", "\r\n "> syntax
+  auto maybe_tokens = lexer::tokenize(R"(replace<"\n", "\r\n ">)");
+  ASSERT_TRUE(maybe_tokens.has_value());
+  std::vector<lexer::Token> &tokens = maybe_tokens.value();
+  auto result =
+      parser::grammar::EscapeReplacement::parse(tokens.cbegin(), tokens.cend());
+  ASSERT_EQ(result.begin, tokens.cend()) << "Should consume all tokens";
+  ASSERT_TRUE(result.node.has_value()) << "Should parse successfully";
+  auto escape = std::get<std::shared_ptr<parser::tree::EscapeReplacement>>(
+      result.node.value());
+  ASSERT_EQ("\n", escape->character) << "Escape character should be newline";
+  ASSERT_EQ("\r\n ", escape->sequence) << "Escape sequence should be CRLF+space";
+}
+
+TEST(TokenPartTest, TokenSequenceOption) {
+  // Test parsing terminator="\r\n" option
+  auto maybe_tokens = lexer::tokenize(R"(terminator="\r\n")");
+  ASSERT_TRUE(maybe_tokens.has_value());
+  std::vector<lexer::Token> &tokens = maybe_tokens.value();
+  auto result =
+      parser::grammar::TokenSequenceOption::parse(tokens.cbegin(), tokens.cend());
+  ASSERT_EQ(result.begin, tokens.cend()) << "Should consume all tokens";
+  ASSERT_TRUE(result.node.has_value()) << "Should parse successfully";
+  auto option = std::get<std::shared_ptr<const parser::tree::TokenSequenceOptionPair>>(
+      result.node.value());
+  ASSERT_EQ("terminator", option->first);
+  auto terminator_value = std::get<std::string>(option->second);
+  ASSERT_EQ("\r\n", terminator_value);
+}
+
+TEST(TokenPartTest, TokenSequenceOptionWithEscape) {
+  // Test parsing escape=replace<"\n", "\r\n "> option
+  auto maybe_tokens = lexer::tokenize(R"(escape=replace<"\n", "\r\n ">)");
+  ASSERT_TRUE(maybe_tokens.has_value());
+  std::vector<lexer::Token> &tokens = maybe_tokens.value();
+  auto result =
+      parser::grammar::TokenSequenceOption::parse(tokens.cbegin(), tokens.cend());
+  ASSERT_EQ(result.begin, tokens.cend()) << "Should consume all tokens";
+  ASSERT_TRUE(result.node.has_value()) << "Should parse successfully";
+  auto option = std::get<std::shared_ptr<const parser::tree::TokenSequenceOptionPair>>(
+      result.node.value());
+  ASSERT_EQ("escape", option->first);
+  auto escape_value = std::get<parser::tree::EscapeReplacement>(option->second);
+  ASSERT_EQ("\n", escape_value.character);
+  ASSERT_EQ("\r\n ", escape_value.sequence);
+}
+
+TEST(TokenPartTest, TokenSequenceWithOptions) {
+  // Test parsing tokens<terminator="\r\n", escape=replace<"\n", "\r\n ">> { host }
+  auto maybe_tokens = lexer::tokenize(
+      R"(tokens<terminator="\r\n", escape=replace<"\n", "\r\n ">> { host })");
+  ASSERT_TRUE(maybe_tokens.has_value());
+  std::vector<lexer::Token> &tokens = maybe_tokens.value();
+  auto result =
+      parser::grammar::TokenSequence::parse(tokens.cbegin(), tokens.cend());
+  ASSERT_EQ(result.begin, tokens.cend()) << "Should consume all tokens";
+  ASSERT_TRUE(result.node.has_value()) << "Should parse successfully";
+  auto seq = std::get<std::shared_ptr<const parser::tree::TokenSequence>>(
+      result.node.value());
+  
+  // Check terminator option
+  ASSERT_TRUE(seq->terminator.has_value()) << "Should have terminator option";
+  ASSERT_EQ("\r\n", seq->terminator.value());
+  
+  // Check escape option
+  ASSERT_TRUE(seq->escape.has_value()) << "Should have escape option";
+  ASSERT_EQ("\n", seq->escape->character);
+  ASSERT_EQ("\r\n ", seq->escape->sequence);
+  
+  // Should have one token part (the identifier "host")
+  ASSERT_EQ(1, seq->tokens.size());
+  auto part = std::get<std::shared_ptr<const parser::tree::IdentifierReference>>(
+      *seq->tokens[0]);
+  ASSERT_EQ("host", part->name);
+}

--- a/tests/023-grammar-complete.cpp
+++ b/tests/023-grammar-complete.cpp
@@ -49,3 +49,46 @@ TEST(MessageTest, Message) {
   ASSERT_EQ("Open", open->when->name);
   ASSERT_EQ("Closed", open->then->name);
 }
+
+TEST(MessageTest, HTTPWithContinuationEscape) {
+  std::string test_file =
+      std::string(TEST_DATA_DIR) + "/038-http-with-continuation.txt";
+  std::ifstream file(test_file);
+  ASSERT_TRUE(file.is_open()) << "Could not open " << test_file;
+  std::string content((std::istreambuf_iterator<char>(file)),
+                      std::istreambuf_iterator<char>());
+  file.close();
+  
+  auto maybe_tokens = lexer::tokenize(content);
+  ASSERT_TRUE(maybe_tokens.has_value()) << "Tokenization failed";
+  
+  std::vector<lexer::Token> &tokens = maybe_tokens.value();
+  auto result = parser::parse(tokens);
+  ASSERT_TRUE(result.has_value()) << "Parsing failed";
+  
+  auto protocol_description = result.value();
+  ASSERT_EQ(3, protocol_description->size());
+
+  // Check Request Line message
+  auto req = protocol_description->at("Request Line");
+  ASSERT_EQ("Request Line", req->name->value);
+  ASSERT_EQ("Open", req->when->name);
+  ASSERT_EQ("ExpectResponse", req->then->name);
+  ASSERT_EQ("Client", req->agent->name);
+  ASSERT_EQ(3, req->data->size()); // method, path, host
+  
+  // Check Response Line message  
+  auto res = protocol_description->at("Response Line");
+  ASSERT_EQ("Response Line", res->name->value);
+  ASSERT_EQ("ExpectResponse", res->when->name);
+  ASSERT_EQ("Done", res->then->name);
+  ASSERT_EQ("Server", res->agent->name);
+  ASSERT_EQ(3, res->data->size()); // status, reason, content_type
+
+  // Check Close Connection message
+  auto close = protocol_description->at("Close Connection");
+  ASSERT_EQ("Close Connection", close->name->value);
+  ASSERT_EQ("Done", close->when->name);
+  ASSERT_EQ("Closed", close->then->name);
+  ASSERT_EQ("Client", close->agent->name);
+}

--- a/tests/024-sema-analyze.cpp
+++ b/tests/024-sema-analyze.cpp
@@ -156,7 +156,7 @@ TEST(MessageTest, Message) {
   auto client_loop_action_1 =
       std::get<std::shared_ptr<const sema::ast::action::WriteStaticOctets>>(
           client_loop_9->actions[1]);
-  ASSERT_EQ(client_loop_action_1->octets, ":");
+  ASSERT_EQ(client_loop_action_1->octets, ": ");
 
   ASSERT_TRUE(std::holds_alternative<
               std::shared_ptr<const sema::ast::action::WriteFromIdentifier>>(
@@ -255,7 +255,7 @@ TEST(MessageTest, Message) {
   auto server_loop_action_0 = std::get<
       std::shared_ptr<const sema::ast::action::ReadOctetsUntilTerminator>>(
       server_loop_5->actions[0]);
-  ASSERT_EQ(server_loop_action_0->terminator, ":");
+  ASSERT_EQ(server_loop_action_0->terminator, ": ");
   ASSERT_EQ(server_loop_action_0->identifier->name, "header");
   ASSERT_TRUE(server_loop_action_0->identifier->member.has_value());
   ASSERT_EQ(server_loop_action_0->identifier->member.value()->name, "key");
@@ -446,7 +446,7 @@ TEST(MessageTest, Message) {
   auto server_write_loop_action_1 =
       std::get<std::shared_ptr<const sema::ast::action::WriteStaticOctets>>(
           server_loop_9->actions[1]);
-  ASSERT_EQ(server_write_loop_action_1->octets, ":");
+  ASSERT_EQ(server_write_loop_action_1->octets, ": ");
 
   ASSERT_TRUE(std::holds_alternative<
               std::shared_ptr<const sema::ast::action::WriteFromIdentifier>>(

--- a/tests/027-translate-ast-to-optree.cpp
+++ b/tests/027-translate-ast-to-optree.cpp
@@ -197,11 +197,11 @@ TEST(TranslateASTToOptree, Translation) {
   server_interpreter_thread.join();
 
   ASSERT_EQ(client_writes.str(), "GET /test HTTP/1.1\r\n"
-                                 "Accept:application/json\r\n"
-                                 "TestHeader:Value\r\n"
+                                 "Accept: application/json\r\n"
+                                 "TestHeader: Value\r\n"
                                  "\r\n");
   ASSERT_EQ(server_writes.str(), "HTTP/1.1 200 Looks good\r\n"
-                                 "Some-Response:some value\r\n"
-                                 "TestHeader:Value\r\n"
+                                 "Some-Response: some value\r\n"
+                                 "TestHeader: Value\r\n"
                                  "\r\n");
 }

--- a/tests/038-escape-replacement-operations.cpp
+++ b/tests/038-escape-replacement-operations.cpp
@@ -1,0 +1,290 @@
+#include <networkprotocoldsl/interpretedprogram.hpp>
+#include <networkprotocoldsl/operation/opsequence.hpp>
+#include <networkprotocoldsl/operation/readoctetsuntilterminator.hpp>
+#include <networkprotocoldsl/operation/writeoctets.hpp>
+#include <networkprotocoldsl/operation/writeoctetswithescape.hpp>
+#include <networkprotocoldsl/optree.hpp>
+#include <networkprotocoldsl/value.hpp>
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include <string_view>
+#include <variant>
+
+// Test escape replacement during reading (parsing)
+// HTTP/1.1 header continuation: "\r\n " on wire becomes "\n" in value
+TEST(EscapeReplacementOperations, ReadWithEscapeReplacement) {
+  using namespace networkprotocoldsl;
+
+  // Input simulates HTTP header with continuation line:
+  // "Content-Type: text/plain;\r\n  charset=utf-8\r\n"
+  // The "\r\n " (CRLF + space) should become "\n" in the parsed value
+  std::string_view input = "text/plain;\r\n  charset=utf-8\r\n";
+
+  // ReadOctetsUntilTerminator with escape replacement:
+  // terminator = "\r\n", escape_char = "\n", escape_sequence = "\r\n "
+  operation::ReadOctetsUntilTerminator read_with_escape("\r\n", "\n", "\r\n ");
+
+  auto optree = std::make_shared<OpTree>(OpTree({read_with_escape, {}}));
+  InterpretedProgram p(optree);
+  Interpreter i = p.get_instance();
+
+  // Step and handle reads until done
+  ContinuationState state;
+  size_t total_consumed = 0;
+  while (true) {
+    state = i.step();
+    if (state == ContinuationState::Exited) {
+      break;
+    }
+    if (state == ContinuationState::Blocked) {
+      auto result = i.get_result();
+      if (std::holds_alternative<ReasonForBlockedOperation>(result)) {
+        if (std::get<ReasonForBlockedOperation>(result) == ReasonForBlockedOperation::WaitingForRead) {
+          size_t consumed = i.handle_read(input.substr(total_consumed));
+          total_consumed += consumed;
+        }
+      }
+    }
+    // Ready: continue stepping
+  }
+
+  // All input should have been consumed
+  EXPECT_EQ(input.size(), total_consumed);
+  
+  auto result = std::get<Value>(i.get_result());
+  auto octets = std::get<value::Octets>(result);
+  
+  // The escape sequence "\r\n " should have been replaced with "\n"
+  EXPECT_EQ("text/plain;\n charset=utf-8", *(octets.data));
+}
+
+// Test that reading without escape still works normally
+TEST(EscapeReplacementOperations, ReadWithoutEscape) {
+  using namespace networkprotocoldsl;
+
+  std::string_view input = "hello world\r\n";
+
+  operation::ReadOctetsUntilTerminator read_no_escape("\r\n");
+
+  auto optree = std::make_shared<OpTree>(OpTree({read_no_escape, {}}));
+  InterpretedProgram p(optree);
+  Interpreter i = p.get_instance();
+
+  // Step and handle reads until done
+  ContinuationState state;
+  size_t total_consumed = 0;
+  while (true) {
+    state = i.step();
+    if (state == ContinuationState::Exited) {
+      break;
+    }
+    if (state == ContinuationState::Blocked) {
+      auto result = i.get_result();
+      if (std::holds_alternative<ReasonForBlockedOperation>(result)) {
+        if (std::get<ReasonForBlockedOperation>(result) == ReasonForBlockedOperation::WaitingForRead) {
+          size_t consumed = i.handle_read(input.substr(total_consumed));
+          total_consumed += consumed;
+        }
+      }
+    }
+    // Ready: continue stepping
+  }
+
+  EXPECT_EQ(input.size(), total_consumed);
+  
+  auto result = std::get<Value>(i.get_result());
+  auto octets = std::get<value::Octets>(result);
+  EXPECT_EQ("hello world", *(octets.data));
+}
+
+// Test multiple escape sequences in one read
+TEST(EscapeReplacementOperations, ReadWithMultipleEscapes) {
+  using namespace networkprotocoldsl;
+
+  // Multiple continuation lines
+  std::string_view input = "line1\r\n line2\r\n line3\r\n";
+
+  operation::ReadOctetsUntilTerminator read_with_escape("\r\n", "\n", "\r\n ");
+
+  auto optree = std::make_shared<OpTree>(OpTree({read_with_escape, {}}));
+  InterpretedProgram p(optree);
+  Interpreter i = p.get_instance();
+
+  // Step and handle reads until done
+  ContinuationState state;
+  size_t total_consumed = 0;
+  while (true) {
+    state = i.step();
+    if (state == ContinuationState::Exited) {
+      break;
+    }
+    if (state == ContinuationState::Blocked) {
+      auto result = i.get_result();
+      if (std::holds_alternative<ReasonForBlockedOperation>(result)) {
+        if (std::get<ReasonForBlockedOperation>(result) == ReasonForBlockedOperation::WaitingForRead) {
+          size_t consumed = i.handle_read(input.substr(total_consumed));
+          total_consumed += consumed;
+        }
+      }
+    }
+    // Ready: continue stepping
+  }
+
+  EXPECT_EQ(input.size(), total_consumed);
+  
+  auto result = std::get<Value>(i.get_result());
+  auto octets = std::get<value::Octets>(result);
+  
+  // Both "\r\n " sequences should become "\n"
+  EXPECT_EQ("line1\nline2\nline3", *(octets.data));
+}
+
+// Test escape replacement during writing (serialization)
+// "\n" in value becomes "\r\n " on wire
+TEST(EscapeReplacementOperations, WriteWithEscapeReplacement) {
+  using namespace networkprotocoldsl;
+
+  // Value with newlines that should be escaped as continuation lines
+  std::string value_str = "text/plain;\n charset=utf-8";
+  auto value_data = std::make_shared<const std::string>(value_str);
+  value::Octets input_value{value_data};
+
+  // WriteOctetsWithEscape: escape_char = "\n", escape_sequence = "\r\n "
+  operation::WriteOctetsWithEscape write_with_escape("\n", "\r\n ");
+
+  auto optree = std::make_shared<OpTree>(
+      OpTree({write_with_escape,
+              {{operation::Int32Literal(0), {}}} // Placeholder, we'll set value manually
+             }));
+  InterpretedProgram p(optree);
+  Interpreter i = p.get_instance();
+
+  // Step to evaluate the literal first
+  ASSERT_EQ(ContinuationState::Ready, i.step());
+
+  // Now step to the write operation - it needs the value as argument
+  // Let's create a simpler test with OpSequence
+}
+
+// Simpler write test using direct operation invocation
+TEST(EscapeReplacementOperations, WriteWithEscapeReplacementDirect) {
+  using namespace networkprotocoldsl;
+
+  operation::WriteOctetsWithEscape write_op("\n", "\r\n ");
+  InputOutputOperationContext ctx;
+
+  std::string value_str = "text/plain;\n charset=utf-8";
+  auto value_data = std::make_shared<const std::string>(value_str);
+  value::Octets input_value{value_data};
+
+  auto result = write_op(ctx, std::make_tuple(Value(input_value)));
+
+  // Should be waiting for write
+  ASSERT_TRUE(std::holds_alternative<ReasonForBlockedOperation>(result));
+  EXPECT_EQ(ReasonForBlockedOperation::WaitingForWrite,
+            std::get<ReasonForBlockedOperation>(result));
+
+  // Check the write buffer has escaped content
+  auto write_buffer = write_op.get_write_buffer(ctx);
+  EXPECT_EQ("text/plain;\r\n  charset=utf-8", std::string(write_buffer));
+}
+
+// Test writing without escape replacement
+TEST(EscapeReplacementOperations, WriteWithoutEscapeDirect) {
+  using namespace networkprotocoldsl;
+
+  operation::WriteOctets write_op;
+  InputOutputOperationContext ctx;
+
+  std::string value_str = "text/plain;\n charset=utf-8";
+  auto value_data = std::make_shared<const std::string>(value_str);
+  value::Octets input_value{value_data};
+
+  auto result = write_op(ctx, std::make_tuple(Value(input_value)));
+
+  ASSERT_TRUE(std::holds_alternative<ReasonForBlockedOperation>(result));
+
+  auto write_buffer = write_op.get_write_buffer(ctx);
+  // Without escape, the value should be unchanged
+  EXPECT_EQ("text/plain;\n charset=utf-8", std::string(write_buffer));
+}
+
+// Test multiple escapes during write
+TEST(EscapeReplacementOperations, WriteWithMultipleEscapesDirect) {
+  using namespace networkprotocoldsl;
+
+  operation::WriteOctetsWithEscape write_op("\n", "\r\n ");
+  InputOutputOperationContext ctx;
+
+  std::string value_str = "line1\nline2\nline3";
+  auto value_data = std::make_shared<const std::string>(value_str);
+  value::Octets input_value{value_data};
+
+  auto result = write_op(ctx, std::make_tuple(Value(input_value)));
+
+  auto write_buffer = write_op.get_write_buffer(ctx);
+  EXPECT_EQ("line1\r\n line2\r\n line3", std::string(write_buffer));
+}
+
+// Test roundtrip: write with escape, then read with escape should give original
+TEST(EscapeReplacementOperations, RoundtripEscapeReplacement) {
+  using namespace networkprotocoldsl;
+
+  // Original value with newlines
+  std::string original = "header: value1\nvalue2\nvalue3";
+
+  // Step 1: Write with escape replacement
+  operation::WriteOctetsWithEscape write_op("\n", "\r\n ");
+  InputOutputOperationContext write_ctx;
+
+  auto value_data = std::make_shared<const std::string>(original);
+  value::Octets input_value{value_data};
+  write_op(write_ctx, std::make_tuple(Value(input_value)));
+
+  std::string wire_format(write_op.get_write_buffer(write_ctx));
+  // Add terminator for reading
+  wire_format += "\r\n";
+
+  // Step 2: Read with escape replacement
+  operation::ReadOctetsUntilTerminator read_op("\r\n", "\n", "\r\n ");
+
+  auto optree = std::make_shared<OpTree>(OpTree({read_op, {}}));
+  InterpretedProgram p(optree);
+  Interpreter i = p.get_instance();
+
+  i.step();
+  i.handle_read(wire_format);
+  i.step();
+
+  auto result = std::get<Value>(i.get_result());
+  auto octets = std::get<value::Octets>(result);
+
+  // Should match original
+  EXPECT_EQ(original, *(octets.data));
+}
+
+// Test stringify methods
+TEST(EscapeReplacementOperations, StringifyWithEscape) {
+  using namespace networkprotocoldsl;
+
+  operation::ReadOctetsUntilTerminator read_op("\r\n", "\n", "\r\n ");
+  std::string read_str = read_op.stringify();
+  EXPECT_TRUE(read_str.find("escape_char") != std::string::npos);
+  EXPECT_TRUE(read_str.find("escape_sequence") != std::string::npos);
+
+  operation::WriteOctetsWithEscape write_op("\n", "\r\n ");
+  std::string write_str = write_op.stringify();
+  EXPECT_TRUE(write_str.find("escape_char") != std::string::npos);
+  EXPECT_TRUE(write_str.find("escape_sequence") != std::string::npos);
+}
+
+TEST(EscapeReplacementOperations, StringifyWithoutEscape) {
+  using namespace networkprotocoldsl;
+
+  operation::ReadOctetsUntilTerminator read_op("\r\n");
+  std::string read_str = read_op.stringify();
+  EXPECT_TRUE(read_str.find("terminator") != std::string::npos);
+  // Should not have escape info
+  EXPECT_TRUE(read_str.find("escape_char") == std::string::npos);
+}

--- a/tests/039-codegen-escape-replacement.cpp
+++ b/tests/039-codegen-escape-replacement.cpp
@@ -1,0 +1,188 @@
+#include <networkprotocoldsl/codegen/generate_parser.hpp>
+#include <networkprotocoldsl/codegen/generate_serializer.hpp>
+#include <networkprotocoldsl/codegen/outputcontext.hpp>
+#include <networkprotocoldsl/codegen/protocolinfo.hpp>
+#include <networkprotocoldsl/lexer/tokenize.hpp>
+#include <networkprotocoldsl/parser/parse.hpp>
+#include <networkprotocoldsl/sema/analyze.hpp>
+
+#include <fstream>
+#include <gtest/gtest.h>
+
+using namespace networkprotocoldsl;
+using namespace networkprotocoldsl::codegen;
+
+class EscapeReplacementCodegenTest : public ::testing::Test {
+protected:
+  std::shared_ptr<const sema::ast::Protocol> protocol_;
+  std::unique_ptr<OutputContext> ctx_;
+  std::unique_ptr<ProtocolInfo> info_;
+
+  void SetUp() override {
+    std::string test_file =
+        std::string(TEST_DATA_DIR) + "/038-http-with-continuation.txt";
+    std::ifstream file(test_file);
+    ASSERT_TRUE(file.is_open()) << "Could not open " << test_file;
+    std::string content((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+    file.close();
+
+    auto maybe_tokens = lexer::tokenize(content);
+    ASSERT_TRUE(maybe_tokens.has_value()) << "Tokenization failed";
+
+    auto result = parser::parse(maybe_tokens.value());
+    ASSERT_TRUE(result.has_value()) << "Parsing failed";
+
+    auto maybe_protocol = sema::analyze(result.value());
+    ASSERT_TRUE(maybe_protocol.has_value()) << "Semantic analysis failed";
+    protocol_ = maybe_protocol.value();
+
+    ctx_ = std::make_unique<OutputContext>("test::http_escape");
+    info_ = std::make_unique<ProtocolInfo>(protocol_);
+  }
+};
+
+// Test that parser code is generated with escape handling
+TEST_F(EscapeReplacementCodegenTest, ParserGeneratesEscapeHandling) {
+  auto result = generate_parser(*ctx_, *info_);
+
+  EXPECT_TRUE(result.errors.empty()) << "Parser generation had errors";
+  EXPECT_FALSE(result.source.empty()) << "Parser source is empty";
+
+  // The generated parser should contain escape sequence handling
+  // Looking for the escape_sequence variable or the replacement logic
+  EXPECT_TRUE(result.source.find("escape_sequence") != std::string::npos ||
+              result.source.find("\\r\\n ") != std::string::npos)
+      << "Parser source should contain escape sequence handling";
+}
+
+// Test that parser handles the specific HTTP continuation escape
+TEST_F(EscapeReplacementCodegenTest, ParserHasHTTPContinuationEscape) {
+  auto result = generate_parser(*ctx_, *info_);
+
+  // Should contain the escape sequence "\r\n " (CRLF + space)
+  // In C++ string literals, this would appear as "\\r\\n "
+  bool has_crlf_space = result.source.find("\\r\\n ") != std::string::npos;
+  
+  EXPECT_TRUE(has_crlf_space)
+      << "Parser should handle CRLF+space escape sequence for HTTP continuation";
+}
+
+// Test that parser has the escape character replacement
+TEST_F(EscapeReplacementCodegenTest, ParserHasEscapeCharReplacement) {
+  auto result = generate_parser(*ctx_, *info_);
+
+  // The parser should insert "\n" when it finds the escape sequence
+  // Look for escape_char or the newline replacement
+  bool has_escape_char = result.source.find("escape_char") != std::string::npos;
+  bool has_newline_replacement = result.source.find("\"\\n\"") != std::string::npos;
+
+  EXPECT_TRUE(has_escape_char || has_newline_replacement)
+      << "Parser should contain escape character replacement logic";
+}
+
+// Test that serializer code is generated with escape handling
+TEST_F(EscapeReplacementCodegenTest, SerializerGeneratesEscapeHandling) {
+  auto result = generate_serializer(*ctx_, *info_);
+
+  EXPECT_TRUE(result.errors.empty()) << "Serializer generation had errors";
+  EXPECT_FALSE(result.source.empty()) << "Serializer source is empty";
+
+  // The generated serializer should contain escape replacement logic
+  // It should replace "\n" with "\r\n " when serializing
+  EXPECT_TRUE(result.source.find("escape") != std::string::npos ||
+              result.source.find("replace") != std::string::npos ||
+              result.source.find("find") != std::string::npos)
+      << "Serializer source should contain escape replacement logic";
+}
+
+// Test that serializer has the specific HTTP continuation escape
+TEST_F(EscapeReplacementCodegenTest, SerializerHasHTTPContinuationEscape) {
+  auto result = generate_serializer(*ctx_, *info_);
+
+  // Should contain logic to replace "\n" with "\r\n "
+  bool has_crlf_space = result.source.find("\\r\\n ") != std::string::npos;
+
+  EXPECT_TRUE(has_crlf_space)
+      << "Serializer should output CRLF+space for HTTP continuation";
+}
+
+// Test that serializer has newline detection
+TEST_F(EscapeReplacementCodegenTest, SerializerHasNewlineDetection) {
+  auto result = generate_serializer(*ctx_, *info_);
+
+  // Should look for "\n" in the value to escape it
+  bool has_newline_search = result.source.find("\"\\n\"") != std::string::npos;
+
+  EXPECT_TRUE(has_newline_search)
+      << "Serializer should search for newlines to escape";
+}
+
+// Test that both parser and serializer are generated without errors
+TEST_F(EscapeReplacementCodegenTest, BothGenerateWithoutErrors) {
+  auto parser_result = generate_parser(*ctx_, *info_);
+  auto serializer_result = generate_serializer(*ctx_, *info_);
+
+  EXPECT_TRUE(parser_result.errors.empty())
+      << "Parser should generate without errors";
+  EXPECT_TRUE(serializer_result.errors.empty())
+      << "Serializer should generate without errors";
+}
+
+// Test that headers are generated correctly
+TEST_F(EscapeReplacementCodegenTest, HeadersAreGenerated) {
+  auto parser_result = generate_parser(*ctx_, *info_);
+  auto serializer_result = generate_serializer(*ctx_, *info_);
+
+  EXPECT_FALSE(parser_result.header.empty())
+      << "Parser header should not be empty";
+  EXPECT_FALSE(serializer_result.header.empty())
+      << "Serializer header should not be empty";
+
+  // Headers should have proper guards
+  EXPECT_TRUE(parser_result.header.find("#ifndef") != std::string::npos);
+  EXPECT_TRUE(serializer_result.header.find("#ifndef") != std::string::npos);
+}
+
+// Test that the protocol info correctly identifies escape sequences
+TEST_F(EscapeReplacementCodegenTest, ProtocolInfoHasEscapeInfo) {
+  // Check that the sema correctly parsed the escape info
+  // The protocol should have messages with escape-enabled fields
+  ASSERT_TRUE(protocol_ != nullptr);
+  
+  bool found_escape = false;
+  
+  // Helper lambda to check an agent's transitions for escape info
+  auto check_agent = [&](const std::shared_ptr<const sema::ast::Agent>& agent) {
+    if (!agent) return;
+    for (const auto& [state_name, state] : agent->states) {
+      for (const auto& [msg_name, trans_pair] : state->transitions) {
+        const auto& [transition, next_state] = trans_pair;
+        
+        std::visit([&](const auto& trans) {
+          for (const auto& action : trans->actions) {
+            if (auto* read_action = std::get_if<std::shared_ptr<const sema::ast::action::ReadOctetsUntilTerminator>>(&action)) {
+              if ((*read_action)->escape.has_value()) {
+                found_escape = true;
+                EXPECT_EQ("\n", (*read_action)->escape->character);
+                EXPECT_EQ("\r\n ", (*read_action)->escape->sequence);
+              }
+            }
+            if (auto* write_action = std::get_if<std::shared_ptr<const sema::ast::action::WriteFromIdentifier>>(&action)) {
+              if ((*write_action)->escape.has_value()) {
+                found_escape = true;
+                EXPECT_EQ("\n", (*write_action)->escape->character);
+                EXPECT_EQ("\r\n ", (*write_action)->escape->sequence);
+              }
+            }
+          }
+        }, transition);
+      }
+    }
+  };
+  
+  check_agent(protocol_->client);
+  check_agent(protocol_->server);
+  
+  EXPECT_TRUE(found_escape) << "Protocol should have at least one field with escape info";
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,8 @@ foreach(
     035-codegen-generate-serializer
     036-codegen-generate-state-machine
     037-codegen-compile-smtp
+    038-escape-replacement-operations
+    039-codegen-escape-replacement
 )
     add_executable(${TEST}.t ${TEST}.cpp)
     target_compile_definitions(${TEST}.t PRIVATE -DTEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")

--- a/tests/data/023-source-code-http-client-server.txt
+++ b/tests/data/023-source-code-http-client-server.txt
@@ -36,9 +36,10 @@ message "HTTP Request" {
         terminator { "\r\n" } 
         for header in headers { 
             tokens { header.key } 
-            terminator { ":" } 
-            tokens { header.value } 
-            terminator { "\r\n"} 
+            terminator { ": " } 
+            // Header values support continuation lines: \r\n followed by space/tab
+            // On wire: "value\r\n continued" becomes "value\n continued" in app
+            tokens<terminator="\r\n", escape=replace<"\n", "\r\n ">> { header.value } 
         } 
         terminator { "\r\n" } 
     } 
@@ -82,9 +83,10 @@ message "HTTP Response" {
         terminator { "\r\n" } 
         for header in headers { 
             tokens { header.key } 
-            terminator { ":" } 
-            tokens { header.value } 
-            terminator { "\r\n"} 
+            terminator { ": " } 
+            // Header values support continuation lines: \r\n followed by space/tab
+            // On wire: "value\r\n continued" becomes "value\n continued" in app
+            tokens<terminator="\r\n", escape=replace<"\n", "\r\n ">> { header.value } 
         } 
         terminator { "\r\n" } 
     } 

--- a/tests/data/038-http-with-continuation.txt
+++ b/tests/data/038-http-with-continuation.txt
@@ -1,0 +1,47 @@
+// HTTP/1.1-like protocol with header continuation line support
+// This tests the escape=replace<"\n", "\r\n "> feature
+// where "\r\n " on the wire represents a newline in the header value
+
+message "Request Line" {
+    when: Open;
+    then: ExpectResponse;
+    agent: Client;
+    data: {
+        method: str<encoding=Ascii7Bit, sizing=Dynamic, max_length=10>;
+        path: str<encoding=Ascii7Bit, sizing=Dynamic, max_length=1024>;
+        host: str<encoding=Ascii7Bit, sizing=Dynamic, max_length=1024>;
+    }
+    parts {
+        tokens { method }
+        terminator { " " }
+        tokens { path }
+        terminator { " HTTP/1.1\r\nHost: " }
+        // host field with escape support - embedded terminator means no terminator block needed
+        tokens<terminator="\r\n\r\n", escape=replace<"\n", "\r\n ">> { host }
+    }
+}
+
+message "Response Line" {
+    when: ExpectResponse;
+    then: Done;
+    agent: Server;
+    data: {
+        status: int<encoding=AsciiInt, unsigned=True, bits=16>;
+        reason: str<encoding=Ascii7Bit, sizing=Dynamic, max_length=256>;
+        content_type: str<encoding=Ascii7Bit, sizing=Dynamic, max_length=1024>;
+    }
+    parts {
+        tokens { "HTTP/1.1 " status }
+        terminator { " " }
+        tokens { reason }
+        terminator { "\r\nContent-Type: " }
+        // content_type field with escape support - embedded terminator
+        tokens<terminator="\r\n\r\n", escape=replace<"\n", "\r\n ">> { content_type }
+    }
+}
+
+message "Close Connection" {
+    when: Done;
+    then: Closed;
+    agent: Client;
+}


### PR DESCRIPTION
Introduce support for an escape sequence when waiting for a terminator (e.g.: `"\r\n "` as an escape for `"\n" in an http header).